### PR TITLE
Feat/linear probing cifar10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ examples/experiment_results
 examples/datacifar10
 examples/CIFAR
 examples/extracted_features
+results/linear_probe_results/extracted_features
+results/linear_probe_results/videos
 datasets
 debug_logs
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,14 @@
 **/data
 **/results/videos
 **/results/images
+**/results/models
 **/wandb
 
 # Specific directories to ignore
 examples/experiment_results
 examples/datacifar10
+examples/CIFAR
+examples/extracted_features
 datasets
 debug_logs
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Predictive coding is a computational framework inspired by the brain's way of pr
 
 Recent works like I-JEPA and V-JEPA (by Meta) aim to improve unsupervised learning by predicting not pixel-level data, but higher-level latent representations. This aligns with the philosophy of predictive coding, where predictions are made in a compressed latent space at multiple levels of abstraction rather than the raw input. I-JEPA and V-JEPA provide compelling evidence that latent-space predictions can lead to more efficient learning, a direction that this proposal seeks to push further.
 
-This research proposal aims to explore the integration of predictive coding with transformer architectures, particularly focusing on parallel local updates and the potential advantages in video prediction and general learning efficiency. By building on recent trends like I-JEPA and V-JEPA, we seek to push the boundaries of how deep learning models can be made more efficient and biologically plausible, potentially offering a new paradigm for training spatiotemporal models.
+This research proposal aims to explore the integration of predictive coding with transformer architectures, particularly focusing on parallel local updates and the potential advantages in video prediction and general learning efficiency. By building on recent trends like I-JEPA and V-JEPA, this research seeks to push the boundaries of how deep learning models can be made more efficient and biologically plausible, potentially offering a new paradigm for training spatiotemporal models.
 
 By proposing a shift from sequential updates to parallel weight updates at each layer, we hypothesize that this method can outperform traditional transformers in both training speed and memory efficiency. Moreover, we aim to investigate how predictive coding can enhance video prediction models, where traditional transformers struggle with minute pixel-level details. This proposal seeks to implement and test these ideas, contributing to the broader field of generative models, unsupervised learning, and spatiotemporal reasoning.
 
@@ -60,7 +60,8 @@ Cora is an active research project. My planned roadmap includes:
 
 *   [x] Implement and validate PC-ViT for masked image reconstruction (CIFAR-10 subset). *(v0.3.0)*
 *   [x] Scale unsupervised training to the full CIFAR-10 dataset. *(v0.4.0 - Successfully trained a 6-block model on the full dataset, achieving ~0.008 MSE)*
-*   [ ] Evaluate learned representations using linear probing on CIFAR-10 classification.
+*   [x] Evaluate learned representations using linear probing on CIFAR-10 classification. *(v0.5.0)
+*   [ ] Experiment with methods for creating more meaningful abstract features, informed by linear probing results.
 *   [ ] Implement label conditioning mechanisms within the PC-ViT architecture.
 *   [ ] Demonstrate label-conditioned image generation on CIFAR-10.
 
@@ -76,6 +77,10 @@ Cora is an active research project. My planned roadmap includes:
 *   [ ] Develop robust PC-Transformer models for video prediction and generation.
 *   [ ] Investigate the efficiency (computational, sample) of PC training compared to standard backpropagation for large transformer models.
 *   [ ] Explore more advanced predictive coding objectives and dynamics within the transformer framework.
+
+### Short Term Goals (Next 1-2 Milestones)
+
+*   **Tune SSL Pretraining for Better Downstream Task Performance**: Leverage the linear probing framework to guide hyperparameter tuning and architectural choices for SSL pretraining, aiming to improve the quality of learned representations for tasks like classification.
 
 ## Citation
 If you find Cora useful in your work, please cite the original PCX paper: [arXiv link](https://arxiv.org/abs/2407.01163) and this repo (an OpenReview paper is coming soon).

--- a/examples/analyze_features.py
+++ b/examples/analyze_features.py
@@ -1,0 +1,196 @@
+import argparse
+import os
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+from sklearn.decomposition import PCA
+from sklearn.manifold import TSNE
+from sklearn.cluster import KMeans
+from scipy.stats import describe
+
+def load_features(file_path):
+    """Loads features from a .npy file."""
+    try:
+        features = np.load(file_path)
+        print(f"Successfully loaded features from: {file_path}")
+        return features
+    except FileNotFoundError:
+        print(f"Error: File not found at {file_path}")
+        return None
+    except Exception as e:
+        print(f"Error loading file {file_path}: {e}")
+        return None
+
+def main():
+    parser = argparse.ArgumentParser(description="Exploratory Data Analysis of Extracted Features")
+    parser.add_argument("--feature_file", type=str, 
+                        default="/home/balazs/Documents/code/cora/examples/extracted_features/6block_layer1_gapTrue_test_features.npy",
+                        help="Path to the .npy file containing the features.")
+    parser.add_argument("--plot_dir", type=str, default="../results/feature_analysis_plots",
+                        help="Directory to save analysis plots.")
+    parser.add_argument("--tsne_perplexity", type=float, default=30.0, help="Perplexity for t-SNE.")
+    parser.add_argument("--tsne_n_iter", type=int, default=1000, help="Number of iterations for t-SNE.")
+    parser.add_argument("--tsne_subset_size", type=int, default=5000, help="Subset size for t-SNE (if full dataset is too large). Set to 0 for full dataset.")
+    parser.add_argument("--n_clusters", type=int, default=10, help="Number of clusters for K-Means.")
+    parser.add_argument("--num_feature_histograms", type=int, default=5, help="Number of individual feature histograms to plot.")
+
+
+    args = parser.parse_args()
+
+    # Create plot directory if it doesn't exist
+    os.makedirs(args.plot_dir, exist_ok=True)
+    
+    # Generate a unique subdirectory for this run's plots
+    run_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    feature_file_name = os.path.splitext(os.path.basename(args.feature_file))[0]
+    run_plot_dir = os.path.join(args.plot_dir, f"{feature_file_name}_{run_timestamp}")
+    os.makedirs(run_plot_dir, exist_ok=True)
+    print(f"Saving plots to: {run_plot_dir}")
+
+    features = load_features(args.feature_file)
+
+    if features is None:
+        return
+
+    print(f"\n--- Basic Information ---")
+    print(f"Features shape: {features.shape}")
+    num_samples, num_features = features.shape
+    print(f"Number of samples: {num_samples}")
+    print(f"Number of features: {num_features}")
+
+    # --- Summary Statistics ---
+    print(f"\n--- Summary Statistics (per feature dimension) ---")
+    features_df = pd.DataFrame(features)
+    summary_stats = features_df.describe()
+    print(summary_stats)
+    summary_stats.to_csv(os.path.join(run_plot_dir, "summary_statistics.csv"))
+    print(f"Saved summary statistics to {os.path.join(run_plot_dir, 'summary_statistics.csv')}")
+
+    # --- Overall Feature Value Distribution ---
+    plt.figure(figsize=(10, 6))
+    sns.histplot(features.flatten(), kde=True, bins=50)
+    plt.title("Overall Distribution of Feature Values")
+    plt.xlabel("Feature Value")
+    plt.ylabel("Frequency")
+    plt.tight_layout()
+    plt.savefig(os.path.join(run_plot_dir, "overall_feature_distribution.png"))
+    plt.close()
+    print("Saved overall feature distribution plot.")
+
+    # --- Individual Feature Histograms ---
+    print(f"\n--- Individual Feature Histograms (Sample of {min(args.num_feature_histograms, num_features)} features) ---")
+    n_hist_to_plot = min(args.num_feature_histograms, num_features)
+    if n_hist_to_plot > 0:
+        # Plot for first N features
+        fig, axes = plt.subplots(1, n_hist_to_plot, figsize=(n_hist_to_plot * 4, 4), sharey=True)
+        if n_hist_to_plot == 1: # Ensure axes is iterable
+            axes = [axes]
+        for i in range(n_hist_to_plot):
+            sns.histplot(features[:, i], kde=True, ax=axes[i], bins=30)
+            axes[i].set_title(f"Feature {i} Distribution")
+            axes[i].set_xlabel("Value")
+        axes[0].set_ylabel("Frequency")
+        plt.suptitle("Distribution of First Few Individual Feature Dimensions", fontsize=16)
+        plt.tight_layout(rect=[0, 0, 1, 0.96])
+        plt.savefig(os.path.join(run_plot_dir, "individual_feature_histograms.png"))
+        plt.close()
+        print(f"Saved individual feature histogram plot for first {n_hist_to_plot} features.")
+
+    # --- Feature Correlation Matrix ---
+    if num_features <= 100: # Avoid overly large correlation matrices
+        print(f"\n--- Feature Correlation Matrix ---")
+        correlation_matrix = np.corrcoef(features, rowvar=False) # features are (samples, features)
+        plt.figure(figsize=(12, 10))
+        sns.heatmap(correlation_matrix, annot=False, cmap='coolwarm', vmin=-1, vmax=1)
+        plt.title("Feature Correlation Matrix")
+        plt.tight_layout()
+        plt.savefig(os.path.join(run_plot_dir, "feature_correlation_heatmap.png"))
+        plt.close()
+        print("Saved feature correlation heatmap.")
+    else:
+        print(f"Skipping feature correlation matrix heatmap as number of features ({num_features}) is > 100.")
+
+    # --- PCA Visualization ---
+    print(f"\n--- PCA Visualization ---")
+    pca = PCA(n_components=2, random_state=42)
+    features_pca = pca.fit_transform(features)
+    print(f"Explained variance ratio (first 2 PCA components): {pca.explained_variance_ratio_}")
+    print(f"Total explained variance (first 2 PCA components): {np.sum(pca.explained_variance_ratio_):.4f}")
+
+    plt.figure(figsize=(10, 8))
+    sns.scatterplot(x=features_pca[:, 0], y=features_pca[:, 1], s=10, alpha=0.7)
+    plt.title("2D PCA of Features")
+    plt.xlabel("PCA Component 1")
+    plt.ylabel("PCA Component 2")
+    plt.tight_layout()
+    plt.savefig(os.path.join(run_plot_dir, "pca_2d_visualization.png"))
+    plt.close()
+    print("Saved 2D PCA visualization.")
+
+    # --- t-SNE Visualization ---
+    print(f"\n--- t-SNE Visualization ---")
+    tsne_samples = features
+    if args.tsne_subset_size > 0 and num_samples > args.tsne_subset_size:
+        print(f"Using a subset of {args.tsne_subset_size} samples for t-SNE for efficiency.")
+        subset_indices = np.random.choice(num_samples, args.tsne_subset_size, replace=False)
+        tsne_samples = features[subset_indices]
+    
+    tsne = TSNE(n_components=2, random_state=42, perplexity=args.tsne_perplexity, n_iter=args.tsne_n_iter, init='pca', learning_rate='auto')
+    features_tsne = tsne.fit_transform(tsne_samples)
+
+    plt.figure(figsize=(10, 8))
+    sns.scatterplot(x=features_tsne[:, 0], y=features_tsne[:, 1], s=10, alpha=0.7)
+    plt.title(f"2D t-SNE of Features (Perplexity: {args.tsne_perplexity}, Samples: {tsne_samples.shape[0]})")
+    plt.xlabel("t-SNE Component 1")
+    plt.ylabel("t-SNE Component 2")
+    plt.tight_layout()
+    plt.savefig(os.path.join(run_plot_dir, "tsne_2d_visualization.png"))
+    plt.close()
+    print("Saved 2D t-SNE visualization.")
+
+    # --- K-Means Clustering ---
+    print(f"\n--- K-Means Clustering (k={args.n_clusters}) ---")
+    kmeans = KMeans(n_clusters=args.n_clusters, random_state=42, n_init='auto')
+    cluster_labels = kmeans.fit_predict(features) # Cluster on original features
+
+    # Visualize clusters on PCA plot
+    plt.figure(figsize=(12, 8))
+    sns.scatterplot(x=features_pca[:, 0], y=features_pca[:, 1], hue=cluster_labels, palette='viridis', s=10, alpha=0.7, legend='full')
+    plt.title(f"2D PCA of Features, Colored by K-Means Clusters (k={args.n_clusters})")
+    plt.xlabel("PCA Component 1")
+    plt.ylabel("PCA Component 2")
+    plt.legend(title='Cluster')
+    plt.tight_layout()
+    plt.savefig(os.path.join(run_plot_dir, "pca_2d_kmeans_clusters.png"))
+    plt.close()
+    print("Saved PCA visualization colored by K-Means clusters.")
+
+    # Visualize clusters on t-SNE plot (using cluster labels from full data, but plotting on t-SNE subset if used)
+    plt.figure(figsize=(12, 8))
+    if args.tsne_subset_size > 0 and num_samples > args.tsne_subset_size:
+        sns.scatterplot(x=features_tsne[:, 0], y=features_tsne[:, 1], hue=cluster_labels[subset_indices], palette='viridis', s=10, alpha=0.7, legend='full')
+    else:
+        sns.scatterplot(x=features_tsne[:, 0], y=features_tsne[:, 1], hue=cluster_labels, palette='viridis', s=10, alpha=0.7, legend='full')
+    plt.title(f"2D t-SNE of Features, Colored by K-Means Clusters (k={args.n_clusters})")
+    plt.xlabel("t-SNE Component 1")
+    plt.ylabel("t-SNE Component 2")
+    plt.legend(title='Cluster')
+    plt.tight_layout()
+    plt.savefig(os.path.join(run_plot_dir, "tsne_2d_kmeans_clusters.png"))
+    plt.close()
+    print("Saved t-SNE visualization colored by K-Means clusters.")
+
+    # Print cluster sizes
+    cluster_counts = pd.Series(cluster_labels).value_counts().sort_index()
+    print("\nCluster sizes:")
+    print(cluster_counts)
+    cluster_counts.to_csv(os.path.join(run_plot_dir, "kmeans_cluster_sizes.csv"))
+    print(f"Saved K-Means cluster sizes to {os.path.join(run_plot_dir, 'kmeans_cluster_sizes.csv')}")
+    
+    print(f"\n--- EDA Script Finished. Plots and stats saved in {run_plot_dir} ---")
+
+if __name__ == '__main__':
+    # Need to import datetime for the timestamp in plot directory naming
+    from datetime import datetime
+    main() 

--- a/examples/hyperparam_search.py
+++ b/examples/hyperparam_search.py
@@ -15,29 +15,34 @@ def perform_hyperparameter_search():
 
     # Fixed overrides: Non-searched parameters, taking cues from the "6block" base
     fixed_overrides = {
-        "epochs": 75,
+        "epochs": 150,
         "theta": 100,
+        "use_ssl_augmentations": False,
+        "use_cifar10_norm": False,
+        "num_images": 3,
         "test_subset": 200,
         "peak_lr_weights": 0.001,
         "hidden_lr_inference": 0.095,
-        "reconstruction_every_n_epochs": 25, 
-        "validation_every_n_epochs": 10,
-        "use_inference_lr_scaling": True, # This controls layer-wise scaling during inference
-        "use_lr_schedule_w": True, # Weights LR is fixed
-        "use_lr_schedule_h": True,  # Hidden LR uses schedule
+        "reconstruction_every_n_epochs": 75,
+        "validation_every_n_epochs": 75,
+        "use_inference_lr_scaling": True,
+        "use_lr_schedule_w": True,
+        "use_lr_schedule_h": True,
         "weight_decay": 2e-4,
         "mlp_ratio": 4.0,
         "patch_size": 4,
         "use_noise": True,
         "update_weights_every_inference_step": False,
+
         "use_early_stopping": True,
         "early_stopping_patience": 7,
-        "early_stopping_min_delta": 0.001,
-
-        # use_vode_state_layernorm will be searched
-        "use_vode_grad_norm": False, 
+        "early_stopping_min_delta": 0.0001,
+        "early_stopping_metric": "train_mse",
+        "save_model_train_mse_threshold": 0.007,
+        "model_saving_metric": "train_mse",
+        
+        "use_vode_grad_norm": False,
         "use_adamw_for_hidden_optimizer": False,
-
         "corrupt_ratio": 0.25,
         "use_lower_half_mask": False,
         "inference_clamp_alpha": 1.0,
@@ -47,21 +52,21 @@ def perform_hyperparameter_search():
         "reinitialize_model_for_each_epoch": False,
         "use_status_init_in_training": False,
         "use_status_init_in_unmasking": False,
-        "lr_schedule_min_lr_factor": 0.5 # New: Factor for min_lr in schedule
+        "lr_schedule_min_lr_factor": 0.5
     }
 
-    # --- Architectural Search Space ---\
-    num_blocks_candidates = [6]
+    # --- Architectural Search Space ---
+    num_blocks_candidates = [1,2,3,4,5,6]
     batch_size_candidates = [200]
     hidden_size_candidates = [64]
     num_heads_candidates = [1]
 
-    # --- Hyperparameter Search Space ---\
+    # --- Hyperparameter Search Space ---
     lr_hidden_candidates = [0.095]
     inference_lr_scale_base_candidates = [1.25]
     hidden_momentum_candidates = [0.4]
     h_grad_clip_norm_candidates = [2000]
-    seed_candidates = [42, 100, 20, 30, 40, 50, 60, 70, 80, 90]
+    seed_candidates = [80]
     inference_steps_candidates = [20]
     warmup_steps_candidates = [0]
     w_grad_clip_norm_candidates = [500.0]
@@ -145,8 +150,8 @@ def perform_hyperparameter_search():
                                                         current_overrides["peak_lr_hidden"] = lr_h
                                                         current_overrides["inference_lr_scale_base"] = scale_base
                                                         current_overrides["inference_steps"] = inf_steps
-                                                        current_overrides["eval_inference_steps"] = [inf_steps]
-                                                        current_overrides["reconstruction_steps"] = [inf_steps]
+                                                        # current_overrides["eval_inference_steps"] = [inf_steps]
+                                                        # current_overrides["reconstruction_steps"] = [inf_steps]
                                                         current_overrides["warmup_steps"] = ws_val
                                                         current_overrides["h_grad_clip_norm"] = h_clip
                                                         current_overrides["w_grad_clip_norm"] = w_clip
@@ -318,7 +323,7 @@ def perform_hyperparameter_search():
             'num_blocks', 'batch_size', 'hidden_size', 'num_heads', 
             'use_vode_state_layernorm', # New
             'peak_lr_hidden', 'inference_lr_scale_base', 'inference_steps',
-            'eval_inference_steps', 'reconstruction_steps', 'warmup_steps',
+            'warmup_steps',
             'h_grad_clip_norm', 'w_grad_clip_norm', 'hidden_momentum', 'seed'
         ]
         

--- a/examples/hyperparam_search.py
+++ b/examples/hyperparam_search.py
@@ -15,12 +15,12 @@ def perform_hyperparameter_search():
 
     # Fixed overrides: Non-searched parameters, taking cues from the "6block" base
     fixed_overrides = {
-        "epochs": 150,
-        "theta": 100,
-        "use_ssl_augmentations": False,
-        "use_cifar10_norm": False,
+        "epochs": 75,
+        "theta": 10_000,
+        "use_ssl_augmentations": True,
+        "use_cifar10_norm": True,
         "num_images": 3,
-        "test_subset": 200,
+        "test_subset": 500,
         "peak_lr_weights": 0.001,
         "hidden_lr_inference": 0.095,
         "reconstruction_every_n_epochs": 75,
@@ -35,7 +35,7 @@ def perform_hyperparameter_search():
         "update_weights_every_inference_step": False,
 
         "use_early_stopping": True,
-        "early_stopping_patience": 7,
+        "early_stopping_patience": 20,
         "early_stopping_min_delta": 0.0001,
         "early_stopping_metric": "train_mse",
         "save_model_train_mse_threshold": 0.007,
@@ -56,8 +56,8 @@ def perform_hyperparameter_search():
     }
 
     # --- Architectural Search Space ---
-    num_blocks_candidates = [1,2,3,4,5,6]
-    batch_size_candidates = [200]
+    num_blocks_candidates = [1]
+    batch_size_candidates = [500]
     hidden_size_candidates = [64]
     num_heads_candidates = [1]
 

--- a/examples/hyperparam_search.py
+++ b/examples/hyperparam_search.py
@@ -16,11 +16,11 @@ def perform_hyperparameter_search():
     # Fixed overrides: Non-searched parameters, taking cues from the "6block" base
     fixed_overrides = {
         "epochs": 75,
-        "theta": 10_000,
-        "use_ssl_augmentations": True,
-        "use_cifar10_norm": True,
-        "num_images": 3,
-        "test_subset": 500,
+        "theta": 100,
+        "use_ssl_augmentations": False,
+        "use_cifar10_norm": False,
+        "num_images": 10,
+        "test_subset": 200,
         "peak_lr_weights": 0.001,
         "hidden_lr_inference": 0.095,
         "reconstruction_every_n_epochs": 75,
@@ -35,10 +35,10 @@ def perform_hyperparameter_search():
         "update_weights_every_inference_step": False,
 
         "use_early_stopping": True,
-        "early_stopping_patience": 20,
-        "early_stopping_min_delta": 0.0001,
+        "early_stopping_patience": 50,
+        "early_stopping_min_delta": 0.001,
         "early_stopping_metric": "train_mse",
-        "save_model_train_mse_threshold": 0.007,
+        "save_model_train_mse_threshold": 0.009,
         "model_saving_metric": "train_mse",
         
         "use_vode_grad_norm": False,
@@ -56,8 +56,8 @@ def perform_hyperparameter_search():
     }
 
     # --- Architectural Search Space ---
-    num_blocks_candidates = [1]
-    batch_size_candidates = [500]
+    num_blocks_candidates = [6]
+    batch_size_candidates = [200]
     hidden_size_candidates = [64]
     num_heads_candidates = [1]
 

--- a/examples/linear_probe.py
+++ b/examples/linear_probe.py
@@ -164,7 +164,11 @@ def create_reconstruction_video(all_reconstruction_frames, orig_images, masked_i
 
     epoch_str = f"_epoch{epoch}" if epoch is not None else "_probe"
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    video_dir = "./extracted_features" # Save in the same dir as other probe outputs
+    
+    # Define the video directory path relative to the project root
+    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__))) # Go up two levels for examples/linear_probe.py
+    video_dir = os.path.join(project_root, "results", "linear_probe_results", "videos")
+    # video_dir = "./extracted_features" # Old path
     os.makedirs(video_dir, exist_ok=True)
     video_path = f"{video_dir}/reconstruction_video{epoch_str}_{timestamp}.mp4"
     imageio.mimsave(video_path, video_frames, fps=fps)
@@ -612,9 +616,15 @@ def main():
         print(f"Shape of extracted '{set_name}' labels: {final_labels_np.shape}")
 
         # Save features and labels
-        os.makedirs("./extracted_features", exist_ok=True)
+        # Define the features directory path relative to the project root
+        project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__))) # Go up two levels for examples/linear_probe.py
+        features_base_dir = os.path.join(project_root, "results", "linear_probe_results", "extracted_features")
+        # os.makedirs("./extracted_features", exist_ok=True) # Old path
+        os.makedirs(features_base_dir, exist_ok=True)
+        
         vode_indices_str_part = "_concat_" + "_".join(map(str, target_vode_indices_local_list)) if concatenate_flag and len(target_vode_indices_local_list) > 1 else "_vode_" + "_".join(map(str, target_vode_indices_local_list))
-        features_path = f"./extracted_features/features{vode_indices_str_part}_{set_name}.npz"
+        # features_path = f"./extracted_features/features{vode_indices_str_part}_{set_name}.npz" # Old path
+        features_path = os.path.join(features_base_dir, f"features{vode_indices_str_part}_{set_name}.npz")
         np.savez_compressed(features_path, features=final_features_np, labels=final_labels_np)
         print(f"Saved '{set_name}' features and labels to {features_path}")
         return features_path
@@ -782,8 +792,12 @@ def main():
 
     # 9. Log all results
     print("\n===== Linear Probe Sweep Results =====")
-    results_log_path = os.path.join("./results", f"linear_probe_sweep_{args.config_name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt")
-    os.makedirs("./results", exist_ok=True)
+    # Define the new results directory path relative to the project root
+    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    results_base_dir = os.path.join(project_root, "results", "linear_probe_results")
+    
+    results_log_path = os.path.join(results_base_dir, f"linear_probe_sweep_{args.config_name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt")
+    os.makedirs(results_base_dir, exist_ok=True)
 
     with open(results_log_path, 'w') as f:
         f.write(f"Linear Probe Sweep Results - Model: {args.model_path}, Config: {args.config_name}\n")

--- a/examples/linear_probe.py
+++ b/examples/linear_probe.py
@@ -1,0 +1,805 @@
+import argparse
+import os
+import sys
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pcx
+import pcx.functional as pxf
+import pcx.utils as pxu
+import pcx.nn as pxnn
+import pcx.predictive_coding as pxc
+from debug_transformer_wandb import MODEL_CONFIGS, ModelConfig # To get config definitions
+from src.decoder_transformer import (
+    TransformerDecoder, TransformerConfig, forward, energy, 
+    apply_exponential_layer_scaling, normalize_vode_h_gradients,
+    unmask_on_batch_enhanced # Import this function
+) # To instantiate model and use PC dynamics
+from tqdm import tqdm # For progress bars
+import imageio
+import matplotlib.pyplot as plt
+from datetime import datetime
+from torch.utils.data import DataLoader, Subset, TensorDataset # Added TensorDataset
+import torchvision
+import torchvision.transforms as transforms
+import torch # Added torch import
+
+# Add project root to path to import from debug_transformer_wandb and src
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Linear Probing for PC-ViT SSL Evaluation")
+    parser.add_argument("--model_path", type=str, required=True,
+                        help="Path to the saved .npz file of the pretrained PC-ViT model (should contain weights and VodeParams).")
+    parser.add_argument("--config_name", type=str, default="6block",
+                        choices=MODEL_CONFIGS.keys(),
+                        help="Name of the ModelConfig used for pretraining the loaded model.")
+    parser.add_argument("--feature_layer_vode_idx", type=int, default=None,
+                        help="Index of the Vode from which to extract features. "
+                             "0 for the top-most latent Vode. "
+                             "Positive indexing for other layers. E.g., num_blocks + 1 for output of last block. "
+                             "Negative indexing: -1 for sensory, -2 for pre-sensory/last block output. "
+                             "If not provided, will sweep through all relevant Vodes.")
+    parser.add_argument("--use_gap", type=lambda x: (str(x).lower() == 'true'), default=True,
+                        help="Whether to apply Global Average Pooling to patch features if they are multi-patch (default: True).")
+    # Linear Probing specific arguments
+    parser.add_argument("--probe_lr", type=float, default=1e-3, help="Learning rate for the linear probe classifier.")
+    parser.add_argument("--probe_wd", type=float, default=1e-4, help="Weight decay for the linear probe classifier.")
+    parser.add_argument("--probe_epochs", type=int, default=100, help="Number of epochs to train the linear probe.")
+    parser.add_argument("--probe_batch_size", type=int, default=256, help="Batch size for training the linear probe.")
+    parser.add_argument("--probe_inference_steps", type=int, default=None, help="Number of inference steps for feature extraction in the probe.")
+    parser.add_argument("--probe_h_lr", type=float, default=None, help="Learning rate for hidden states (h) during feature extraction.")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed for initializing the linear probe and other stochastic operations.")
+    # Add more args later for linear classifier training (lr, epochs, etc.)
+    return parser.parse_args()
+
+def create_reconstruction_video(all_reconstruction_frames, orig_images, masked_images, labels_list, num_images, image_shape, wandb_run, epoch, fps=10, reconstruction_mses=None):
+    """
+    Creates a video comparing original images and their reconstructions over time.
+    Adds MSE to the title of the reconstruction if provided.
+
+    Args:
+        all_reconstruction_frames: List (num_images) of lists (T_steps) of reconstruction tensors.
+        orig_images: List of original image tensors.
+        masked_images: List of masked input image tensors.
+        labels_list: List of labels for the original images.
+        num_images: Number of images to include in the video.
+        image_shape: Shape of a single image (C, H, W).
+        wandb_run: Wandb run object (can be None).
+        epoch: Current epoch number (can be None).
+        fps: Frames per second for the video.
+        reconstruction_mses: List of MSE values for each image.
+
+    Returns:
+        Tuple: (video_path, log_dict)
+    """
+    num_channels, H, W = image_shape
+    num_steps = len(all_reconstruction_frames[0]) # Assuming all images have same number of steps
+
+    video_frames = []
+
+    # Prepare original images once
+    processed_orig_images = []
+    processed_masked_images = []
+    for i in range(num_images):
+        orig_np = np.array(orig_images[i])
+        masked_np = np.array(masked_images[i])
+        if num_channels == 1: # Grayscale
+            orig_plot = np.clip(np.squeeze(orig_np), 0.0, 1.0)
+            orig_plot = (plt.cm.gray(orig_plot)[:, :, :3] * 255).astype(np.uint8) # Convert grayscale to RGB for video
+            masked_plot = np.clip(np.squeeze(masked_np), 0.0, 1.0)
+            masked_plot = (plt.cm.gray(masked_plot)[:, :, :3] * 255).astype(np.uint8)
+        else: # RGB
+            orig_plot = np.clip(np.transpose(orig_np, (1, 2, 0)), 0.0, 1.0)
+            orig_plot = (orig_plot * 255).astype(np.uint8)
+            masked_plot = np.clip(np.transpose(masked_np, (1, 2, 0)), 0.0, 1.0)
+            masked_plot = (masked_plot * 255).astype(np.uint8)
+        processed_orig_images.append(orig_plot)
+        processed_masked_images.append(masked_plot)
+
+    # Generate frames for the video
+    for t in range(num_steps):
+        fig, axes = plt.subplots(num_images, 3, figsize=(4 * 3, 2 * num_images))
+        if num_images == 1:
+            axes = axes[None, :] # Make it 2D
+
+        for i in range(num_images):
+            # Plot original image (Column 0)
+            axes[i, 0].imshow(processed_orig_images[i])
+            axes[i, 0].set_title(f'Original {labels_list[i] if labels_list[i] is not None else ""}')
+            axes[i, 0].axis('off')
+
+            # Plot masked input (Column 1)
+            axes[i, 1].imshow(processed_masked_images[i])
+            axes[i, 1].set_title(f'Masked Input') # For probe, masked might just be original
+            axes[i, 1].axis('off')
+
+            # Plot reconstruction at step t (Column 2)
+            recon_t = all_reconstruction_frames[i][t]
+            recon_np = np.array(recon_t[0]) # Get the first element from batch dim
+            recon_np = np.reshape(recon_np, image_shape)
+            current_mse_str = f" (MSE: {reconstruction_mses[i]:.4f})" if reconstruction_mses and i < len(reconstruction_mses) else ""
+
+            if num_channels == 1: # Grayscale
+                recon_plot = np.clip(np.squeeze(recon_np), 0.0, 1.0)
+                recon_plot = (plt.cm.gray(recon_plot)[:, :, :3] * 255).astype(np.uint8)
+            else: # RGB
+                recon_plot = np.clip(np.transpose(recon_np, (1, 2, 0)), 0.0, 1.0)
+                recon_plot = (recon_plot * 255).astype(np.uint8)
+            
+            axes[i, 2].imshow(recon_plot)
+            axes[i, 2].set_title(f'Recon T={t+1}{current_mse_str}')
+            axes[i, 2].axis('off')
+        
+        plt.tight_layout()
+        fig.canvas.draw() # Draw the canvas, cache the renderer
+        frame = np.frombuffer(fig.canvas.tostring_rgb(), dtype='uint8')
+
+        width_inches, height_inches = fig.get_size_inches()
+        dpi = fig.dpi
+        width_pixels = int(np.round(width_inches * dpi))
+        height_pixels = int(np.round(height_inches * dpi))
+        expected_shape = (height_pixels, width_pixels, 3)
+
+        if frame.size != np.prod(expected_shape):
+            print(f"Warning: Buffer size ({frame.size}) does not match calculated shape {expected_shape} ({np.prod(expected_shape)}). Trying to infer shape.")
+            buffer_pixels = frame.size // 3
+            fig_width_inches, fig_height_inches = fig.get_size_inches()
+            aspect_ratio = fig_width_inches / fig_height_inches if fig_height_inches > 0 else 1
+            inferred_height = int(np.sqrt(buffer_pixels / aspect_ratio))
+            inferred_width = int(inferred_height * aspect_ratio)
+            if inferred_height * inferred_width * 3 == frame.size:
+                 expected_shape = (inferred_height, inferred_width, 3)
+                 print(f"Using inferred shape: {expected_shape}")
+            else:
+                 print(f"Error: Cannot determine correct frame shape. Buffer size: {frame.size}, Calculated shape: {(height_pixels, width_pixels, 3)}, Inferred shape: {(inferred_height, inferred_width, 3)}")
+                 raise ValueError(f"Cannot reshape array of size {frame.size} into calculated shape {(height_pixels, width_pixels, 3)} or inferred shape {(inferred_height, inferred_width, 3)}")
+
+        frame = frame.reshape(expected_shape)
+        video_frames.append(frame)
+        plt.close(fig)
+
+    epoch_str = f"_epoch{epoch}" if epoch is not None else "_probe"
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    video_dir = "./extracted_features" # Save in the same dir as other probe outputs
+    os.makedirs(video_dir, exist_ok=True)
+    video_path = f"{video_dir}/reconstruction_video{epoch_str}_{timestamp}.mp4"
+    imageio.mimsave(video_path, video_frames, fps=fps)
+    print(f"Saved reconstruction video to {video_path}")
+
+    log_dict = {}
+    if wandb_run is not None:
+        # Attempt to import wandb only if needed
+        try:
+            import wandb
+            log_key = f"reconstructions_video{epoch_str}" if epoch is not None else "reconstructions_video_probe"
+            log_dict[log_key] = wandb.Video(video_path, fps=fps, format="mp4")
+        except ImportError:
+            print("wandb module not found, skipping W&B video logging.")
+        except Exception as e:
+            print(f"Error creating wandb.Video: {e}")
+            print("Ensure ffmpeg is installed and accessible.")
+
+    return video_path, log_dict
+
+def main():
+    args = parse_args()
+
+    print("--- Linear Probing Setup ---")
+    print(f"Loading pretrained model from: {args.model_path}")
+    print(f"Using base config: {args.config_name}")
+    print(f"Extracting features from Vode index: {args.feature_layer_vode_idx}")
+    print(f"Using Global Average Pooling: {args.use_gap}")
+
+    # 1. Load ModelConfig used for pretraining
+    if args.config_name not in MODEL_CONFIGS:
+        raise ValueError(f"Config name '{args.config_name}' not found in MODEL_CONFIGS.")
+    
+    # Create a new instance of the config, we might override parts of it if they were
+    # changed during the specific run that saved the model, but hyperparam_search.py
+    # doesn't save the full config, only the overrides. For now, assume base config is enough.
+    # In a more robust setup, the saved model artifact would include its exact config.
+    base_model_config_obj: ModelConfig = MODEL_CONFIGS[args.config_name]
+
+    # Create the TransformerConfig for the model architecture
+    # We need to map ModelConfig fields to TransformerConfig fields
+    transformer_arch_config = TransformerConfig(
+        image_shape=tuple(map(int, MODEL_CONFIGS[args.config_name].dataset_img_shape)) if hasattr(MODEL_CONFIGS[args.config_name], 'dataset_img_shape') else (3, 32, 32), # TODO: Make this more robust
+        num_frames=MODEL_CONFIGS[args.config_name].num_frames if hasattr(MODEL_CONFIGS[args.config_name], 'num_frames') else 16, # Default, adjust if needed
+        is_video=MODEL_CONFIGS[args.config_name].is_video if hasattr(MODEL_CONFIGS[args.config_name], 'is_video') else False, # Default
+        hidden_size=base_model_config_obj.hidden_size,
+        num_heads=base_model_config_obj.num_heads,
+        num_blocks=base_model_config_obj.num_blocks,
+        mlp_ratio=base_model_config_obj.mlp_ratio,
+        patch_size=base_model_config_obj.patch_size,
+        axes_dim=base_model_config_obj.axes_dim,
+        theta=base_model_config_obj.theta,
+        act_fn=base_model_config_obj.act_fn,
+        # SSL specific flags are not directly relevant for architecture, but for feature extraction behavior
+        use_noise=base_model_config_obj.use_noise, 
+        use_lower_half_mask=base_model_config_obj.use_lower_half_mask,
+        use_status_init_in_training=base_model_config_obj.use_status_init_in_training, # Might influence how we get 'settled' h
+        use_status_init_in_unmasking=base_model_config_obj.use_status_init_in_unmasking, # Might influence how we get 'settled' h
+        use_inference_lr_scaling=base_model_config_obj.use_inference_lr_scaling,
+        inference_lr_scale_base=base_model_config_obj.inference_lr_scale_base,
+        update_weights_every_inference_step=base_model_config_obj.update_weights_every_inference_step,
+        use_vode_state_layernorm=base_model_config_obj.use_vode_state_layernorm,
+        use_vode_grad_norm=base_model_config_obj.use_vode_grad_norm,
+        vode_grad_norm_target=base_model_config_obj.vode_grad_norm_target
+    )
+    
+    print("\n--- Initializing Model Architecture ---")
+    model = TransformerDecoder(transformer_arch_config)
+
+    # Initialize model parameters (needed before loading)
+    # Create a dummy input matching the expected batch size for model parameter initialization
+    # The batch size here doesn't have to match training/pretraining, just for init.
+    # However, the feature extraction will use a specific batch size from the dataloader.
+    # Let's use a placeholder batch size of 1 for initialization, as pcx sometimes
+    # initializes params based on the first call if not explicitly done.
+    # Better: use the actual batch_size from the ModelConfig if available, or a default.
+    # For now, using the original approach from debug_transformer_wandb
+    
+    # The pcx model usually initializes its parameters when first called with data,
+    # or specifically when pxu.load_params is called on a model that has had its
+    # parameters built (e.g. by a first forward pass).
+    # We need to ensure the model structure is built.
+    # A common way in pcx is to do a STATUS.INIT pass.
+    
+    key = jax.random.PRNGKey(0) # Dummy key for init
+    # Use batch_size from the loaded config for init, or a default like 1 if not critical
+    # The actual batching for feature extraction will come from the dataloader.
+    # Using the config's batch_size is more consistent.
+    init_batch_size = base_model_config_obj.batch_size 
+    
+    # Ensure image_shape is correctly derived for dummy input
+    if transformer_arch_config.is_video:
+        dummy_input_shape = (init_batch_size, *transformer_arch_config.image_shape)
+    else:
+        # Ensure image_shape from TransformerConfig is (C, H, W)
+        if len(transformer_arch_config.image_shape) == 3:
+             dummy_input_shape = (init_batch_size, *transformer_arch_config.image_shape)
+        elif len(transformer_arch_config.image_shape) == 2: # (H,W) for grayscale, add C
+             dummy_input_shape = (init_batch_size, 1, *transformer_arch_config.image_shape)
+        else:
+            raise ValueError(f"Unexpected image_shape format for non-video: {transformer_arch_config.image_shape}")
+
+
+    x_init_dummy = jnp.zeros(dummy_input_shape, dtype=jnp.float32)
+    
+    print(f"Performing initial model forward pass with dummy input shape: {x_init_dummy.shape} to build parameters...")
+    with pxu.step(model, pxc.STATUS.INIT, clear_params=pxc.VodeParam.Cache):
+        forward(x_init_dummy, model=model)
+    print("Model parameters built.")
+
+    # 2. Load saved weights AND VodeParams (activations/latents)
+    try:
+        # Load both LayerParams (weights) and VodeParams (h, u states)
+        pxu.load_params(model, args.model_path, filter=lambda x: isinstance(x, (pxnn.LayerParam, pxc.VodeParam)))
+        print(f"Successfully loaded LayerParams (weights) AND VodeParams (activations) from {args.model_path}")
+    except Exception as e:
+        print(f"Error loading model weights and VodeParams: {e}")
+        print("Ensure the model_path is correct and the .npz file contains LayerParam and VodeParam entries matching the model architecture.")
+        sys.exit(1)
+
+    # 3. Freeze all model weights (LayerParams)
+    # In pcx, freezing is typically handled by not including params in the optimizer's target.
+    # For feature extraction, we simply won't update them.
+    # If we were to use pcx's own parameter freezing, it would be:
+    # for param in pxu.Parameters(model).select(pxnn.LayerParam):
+    #     param.frozen = True
+    # But since we are not calling an optimizer on these weights, it's implicitly frozen.
+    print("Model weights (LayerParams) will be treated as frozen for feature extraction.")
+
+    # 4. Setup CIFAR-10 Dataloaders for feature extraction
+    print("\n--- Setting up CIFAR-10 Dataloaders ---")
+    import torch
+    import torchvision
+    import torchvision.transforms as transforms
+    from torch.utils.data import DataLoader
+
+    # Standard CIFAR-10 normalization
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
+    ])
+
+    # We'll use the batch_size from the loaded config for feature extraction, can be overridden later if needed
+    # For linear probing, batch size during feature extraction isn't super critical for accuracy, more for speed.
+    feature_extraction_batch_size = base_model_config_obj.batch_size
+
+    try:
+        train_dataset = torchvision.datasets.CIFAR10(root='./data', train=True, download=True, transform=transform)
+        test_dataset = torchvision.datasets.CIFAR10(root='./data', train=False, download=True, transform=transform)
+    except Exception as e:
+        print(f"Error downloading CIFAR-10: {e}. Trying with alternative root.")
+        alt_data_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'datasets')
+        os.makedirs(alt_data_dir, exist_ok=True)
+        train_dataset = torchvision.datasets.CIFAR10(root=alt_data_dir, train=True, download=True, transform=transform)
+        test_dataset = torchvision.datasets.CIFAR10(root=alt_data_dir, train=False, download=True, transform=transform)
+
+
+    train_loader = DataLoader(train_dataset, batch_size=feature_extraction_batch_size, shuffle=False, num_workers=0)
+    test_loader = DataLoader(test_dataset, batch_size=feature_extraction_batch_size, shuffle=False, num_workers=0)
+
+    print(f"CIFAR-10 train dataset size: {len(train_dataset)}")
+    print(f"CIFAR-10 test dataset size: {len(test_dataset)}")
+    print(f"Feature extraction batch size: {feature_extraction_batch_size}")
+
+    # 5. Setup optimizer for h-states during inference for feature extraction
+    # This is similar to optim_h_inference in debug_transformer_wandb.py
+    # It should use the inference-specific LR and momentum from the loaded config.
+    import optax
+    print("\n--- Setting up Optimizer for Hidden States (h) during Feature Extraction ---")
+
+    # Use hidden_lr_inference and hidden_momentum from the loaded config
+    # These were part of ModelConfig, not TransformerConfig, so access via base_model_config_obj
+    
+    # Determine h_inference_lr for feature extraction
+    if args.probe_h_lr is not None:
+        h_inference_lr = args.probe_h_lr
+        print(f"Using probe_h_lr from CLI for feature extraction: {h_inference_lr}")
+    else:
+        h_inference_lr = 0.055 # Default to 0.055 if not provided
+        print(f"Using default h_inference_lr for feature extraction: {h_inference_lr}")
+    
+    h_momentum = base_model_config_obj.hidden_momentum
+    h_grad_clip = base_model_config_obj.h_grad_clip_norm
+
+    if base_model_config_obj.use_adamw_for_hidden_optimizer:
+        print(f"Using AdamW for hidden state inference optimizer with LR: {h_inference_lr}")
+        base_optim_h_feat_extract = optax.adamw(learning_rate=h_inference_lr, b1=0.9, b2=0.999, eps=1e-8)
+    else:
+        print(f"Using SGD for hidden state inference optimizer with LR: {h_inference_lr}, Momentum: {h_momentum}")
+        base_optim_h_feat_extract = optax.sgd(h_inference_lr, momentum=h_momentum)
+
+    optim_h_feat_extract_steps = []
+    if h_grad_clip is not None and h_grad_clip > 0:
+        print(f"Applying H-gradient clipping for feature extraction with max_norm = {h_grad_clip}")
+        h_clipper_feat_extract = optax.clip_by_global_norm(h_grad_clip)
+        optim_h_feat_extract_steps.append(h_clipper_feat_extract)
+    
+    optim_h_feat_extract_steps.append(base_optim_h_feat_extract)
+    final_optim_h_for_feature_extraction = optax.chain(*optim_h_feat_extract_steps)
+    optim_h_extractor = pxu.Optim(lambda: final_optim_h_for_feature_extraction)
+
+    print("Optimizer for h-states (optim_h_extractor) configured.")
+
+    # Determine inference steps for extraction (moved earlier for visualization use)
+    if args.probe_inference_steps is not None:
+        inference_steps_for_extraction = args.probe_inference_steps
+        print(f"Using probe_inference_steps from CLI for feature extraction and visualization: {inference_steps_for_extraction}")
+    else:
+        inference_steps_for_extraction = 40 # Default to 40 if not provided
+        print(f"Using default probe_inference_steps for feature extraction and visualization: {inference_steps_for_extraction}")
+
+    # --- Add Reconstruction Visualization --- 
+    print("\n--- Generating Reconstruction Visualization --- ")
+    vis_num_images = 2
+    # Use the determined inference_steps_for_extraction for the visualization target T values
+    # vis_target_T_values will be a list with a single element: the final step number.
+    vis_target_T_values = [inference_steps_for_extraction]
+    print(f"Visualization will use T_values: {vis_target_T_values} (derived from probe_inference_steps or its default)")
+
+    vis_fps = base_model_config_obj.video_fps
+    vis_image_shape = transformer_arch_config.image_shape # This is (C,H,W)
+
+    # Conditional initial visualization
+    if args.feature_layer_vode_idx is not None: # Only run initial viz if a specific Vode is targeted
+        # Get a batch from the test_loader for visualization
+        try:
+            vis_batch_pt_full, vis_labels_pt_full = next(iter(test_loader))
+        except StopIteration:
+            print("Error: Could not get a batch from test_loader for visualization.")
+            vis_batch_pt_full = None
+
+        if vis_batch_pt_full is not None:
+            model.eval() # Ensure model is in eval mode
+            
+            all_images_all_recons_list = [] # To store [[img1_recons_steps], [img2_recons_steps]]
+            all_images_orig_for_video = []
+            all_images_labels_for_video = []
+            all_images_recon_loss = []
+
+            for i in range(vis_num_images):
+                print(f"Processing image {i+1}/{vis_num_images} for reconstruction video...")
+                single_image_np = vis_batch_pt_full[i:i+1].numpy() # Batch of 1 image
+                single_label_np = vis_labels_pt_full[i:i+1].numpy()
+
+                all_images_orig_for_video.append(single_image_np[0]) # Store unbatched image
+                all_images_labels_for_video.append(single_label_np[0])
+
+                recon_loss_single, single_img_all_recons_list, _, _ = unmask_on_batch_enhanced(
+                    use_corruption=False,
+                    corrupt_ratio=0.0,
+                    target_T_values=vis_target_T_values,
+                    x=jnp.array(single_image_np), # Pass single image as JAX array
+                    model=model,
+                    optim_h=optim_h_extractor,
+                    optim_w=None
+                )
+                all_images_all_recons_list.append(single_img_all_recons_list)
+                all_images_recon_loss.append(recon_loss_single)
+                print(f"  Reconstruction loss for image {i+1}: {recon_loss_single:.4f}")
+
+            if all_images_all_recons_list:
+                # create_reconstruction_video expects: List (num_images) of lists (T_steps) of reconstruction tensors.
+                # Each inner list (T_steps) should contain tensors of shape (1, C, H, W) or (C,H,W) if squeezed later.
+                # single_img_all_recons_list already contains [step0_recon_batch_of_1, step1_recon_batch_of_1, ...]
+                # So, all_images_all_recons_list is already in the correct format.
+                create_reconstruction_video(
+                    all_reconstruction_frames=all_images_all_recons_list,
+                    orig_images=all_images_orig_for_video,
+                    masked_images=all_images_orig_for_video, # Same as original for no corruption
+                    labels_list=all_images_labels_for_video,
+                    num_images=vis_num_images,
+                    image_shape=vis_image_shape,
+                    wandb_run=None, 
+                    epoch=None,     
+                    fps=vis_fps,
+                    reconstruction_mses=all_images_recon_loss 
+                )
+    # --- End Reconstruction Visualization ---
+    else:
+        print("Skipping initial reconstruction visualization because running in Vode sweep mode.")
+
+    # 6. Define feature extraction function
+    @pxf.jit(static_argnums=(3, 4, 5)) # Jit this function for speed after debugging
+    def extract_features_from_batch(x_batch_np, model_instance, optim_h, inference_steps_for_extraction, target_vode_idx, use_gap_flag):
+        x_batch_jnp = jnp.array(x_batch_np)
+
+        # A. Initialize optimizer state for the current model state (which includes loaded VodeParams)
+        optim_h.clear()
+        optim_h.init(pxu.M_hasnot(pxc.VodeParam, frozen=True)(model_instance)) # Target non-frozen VodeParams
+
+        # B. Initial forward pass to set sensory Vode and allow initial propagation
+        # Determine if STATUS.INIT should be used based on PRETRAINING config for UNMASKING (or training if unmasking not set)
+        # For feature extraction, we usually want the model to adapt to the new input x_batch.
+        # If the loaded VodeParams are a generic "prior", then STATUS.INIT might reset them too aggressively.
+        # Let's assume for now we do NOT use STATUS.INIT, and instead let the loaded VodeParams be the starting point
+        # and the inference steps will adapt them to x_batch.
+        # The sensory Vode (vodes[-1]) will be set by the forward(x_batch_jnp, ...) call.
+        
+        with pxu.step(model_instance, clear_params=pxc.VodeParam.Cache): # No STATUS.INIT here
+            model_instance.vodes[-1].h.frozen = False # Ensure sensory is not frozen for this initial setting
+            forward(x_batch_jnp, model=model_instance) # This sets model.vodes[-1].h to x_batch_jnp
+            model_instance.vodes[-1].h.frozen = True  # Re-freeze sensory after its set to the input
+
+        # C. Run T_h inference steps to let latents converge for this batch
+        # inference_steps_for_extraction is now passed directly
+        
+        # Define the energy function for gradient calculation (consistent with SSL pretraining)
+        # This targets non-frozen VodeParams for gradient calculation.
+        inference_step_fn_grad = pxf.value_and_grad(pxu.M_hasnot(pxc.VodeParam, frozen=True).to([False, True]), has_aux=True)(energy)
+
+        for _ in range(inference_steps_for_extraction):
+            with pxu.step(model_instance, clear_params=pxc.VodeParam.Cache):
+                # Get energy and gradients for h (non-frozen VodeParams)
+                (_, _), h_grad = inference_step_fn_grad(model=model_instance)
+            
+            model_grads_to_apply = h_grad["model"] # Grads for VodeParams
+
+            # Apply scaling if it was used during pretraining
+            if model_instance.config.use_inference_lr_scaling:
+                model_grads_to_apply = apply_exponential_layer_scaling(
+                    model_grads=model_grads_to_apply,
+                    config=model_instance.config # Use the model's internal TransformerConfig
+                )
+            
+            # Apply Vode h-gradient normalization if it was used during pretraining
+            if model_instance.config.use_vode_grad_norm:
+                model_grads_to_apply = normalize_vode_h_gradients(
+                    model_grads=model_grads_to_apply,
+                    config=model_instance.config # Use the model's internal TransformerConfig
+                )
+            
+            optim_h.step(model_instance, model_grads_to_apply)
+
+        # D. Extract features from the target Vode
+        # Ensure target_vode_idx is valid
+        num_vodes = len(model_instance.vodes)
+        actual_idx = target_vode_idx
+        if actual_idx < 0:
+            actual_idx = num_vodes + actual_idx # Convert negative index to positive
+        
+        if not (0 <= actual_idx < num_vodes):
+            raise ValueError(f"Invalid feature_layer_vode_idx: {target_vode_idx} (resolved to {actual_idx}). Model has {num_vodes} vodes.")
+
+        # Get the h-state of the target Vode
+        # We need to do a final forward pass with STATUS_FORWARD to ensure u states are current if the target Vode uses them
+        # However, we are interested in the h state itself.
+        # The h states are updated by optim_h.step().
+        h_param = model_instance.vodes[actual_idx].h # Get the Param object
+        extracted_h_features_array = h_param._value # Get the underlying JAX array
+
+        # E. Apply Global Average Pooling if specified and features are per-patch
+        # Features from vodes[0] are (batch, num_patches, patch_dim) or (batch, hidden_size) if top-level is single vector
+        # Features from intermediate transformer blocks are (batch, num_patches, hidden_size)
+        # Sensory vode vodes[-1] h is (batch, C, H, W)
+        if use_gap_flag:
+            if actual_idx == num_vodes -1 : # Sensory layer
+                print(f"Warning: GAP requested for sensory layer (Vode {actual_idx}). Applying mean over spatial dims (H, W).")
+                if extracted_h_features_array.ndim == 4: # (B, C, H, W)
+                    extracted_h_features_array = jnp.mean(extracted_h_features_array, axis=(2,3)) # -> (B, C)
+                elif extracted_h_features_array.ndim == 3: # (B, H, W) for grayscale
+                    extracted_h_features_array = jnp.mean(extracted_h_features_array, axis=(1,2)) # -> (B,)
+            elif extracted_h_features_array.ndim == 3: # Likely (batch, num_patches, feature_dim)
+                extracted_h_features_array = jnp.mean(extracted_h_features_array, axis=1) # GAP over patches -> (batch, feature_dim)
+            elif extracted_h_features_array.ndim == 2: # Already (batch, feature_dim), GAP not needed or already applied by Vode structure
+                print(f"Note: Features from Vode {actual_idx} are already 2D. GAP not applied over patch dimension.")
+            else:
+                print(f"Warning: Cannot apply GAP to features from Vode {actual_idx} with shape {extracted_h_features_array.shape}. Returning as is.")
+        
+        return extracted_h_features_array # Return the JAX array
+
+    # 7. Extract features for train and test sets
+    print("\n--- Extracting Features ---")
+    
+    def extract_and_save_features(loader, set_name, model_instance_local, optim_h_local, inference_steps_local, target_vode_idx_local, use_gap_local):
+        all_features_list = []
+        all_labels_list = []
+        print(f"Extracting features for {set_name} set...")
+        for x_batch_pt, y_labels_pt in tqdm(loader, desc=f"Extracting {set_name} features"):
+            batch_features_jnp = extract_features_from_batch(
+                x_batch_pt.numpy(), # Convert PyTorch tensor to NumPy array
+                model_instance_local, 
+                optim_h_local, 
+                inference_steps_local, 
+                target_vode_idx_local, 
+                use_gap_local
+            )
+            all_features_list.append(np.array(batch_features_jnp))
+            all_labels_list.append(y_labels_pt.numpy()) # Convert PyTorch tensor to NumPy array
+        
+        # Concatenate all features and labels from the list of batches
+        all_features_np = np.concatenate(all_features_list, axis=0)
+        all_labels_np = np.concatenate(all_labels_list, axis=0)
+
+        # Save features and labels
+        features_path = os.path.join("./extracted_features", f"{args.config_name}_layer{target_vode_idx_local}_gap{use_gap_local}_{set_name}_features.npy")
+        labels_path = os.path.join("./extracted_features", f"{args.config_name}_layer{target_vode_idx_local}_gap{use_gap_local}_{set_name}_labels.npy")
+        np.save(features_path, all_features_np)
+        np.save(labels_path, all_labels_np)
+        print(f"Saved {set_name} features to: {features_path} (Shape: {all_features_np.shape})")
+        print(f"Saved {set_name} labels to: {labels_path} (Shape: {all_labels_np.shape})")
+
+    # Determine which Vode indices to run the probe for
+    if args.feature_layer_vode_idx is not None:
+        vode_indices_to_probe = [args.feature_layer_vode_idx]
+        print(f"Probing specified Vode index: {vode_indices_to_probe}")
+    else:
+        # Sweep from Vode 0 (top-most) to Vode num_blocks + 1 (output of last transformer block)
+        # Vode indices:
+        # 0: Top-most latent
+        # 1: Output of patch projection
+        # 2 to num_blocks + 1: Output of each transformer block
+        # num_blocks + 2: Sensory Vode (usually not used for features)
+        num_total_vodes_in_model = base_model_config_obj.num_blocks + 2 # Vode 0, proj_vode, N block vodes
+        vode_indices_to_probe = list(range(num_total_vodes_in_model))
+        print(f"Sweeping through Vode indices: {vode_indices_to_probe}")
+
+    # --- Define Linear Classifier Components ---
+    # These are defined once here, to be in scope for the loop below.
+    def linear_classifier_predict(params_local, x_local):
+        return jnp.dot(x_local, params_local['W']) + params_local['b']
+
+    def cross_entropy_loss(params_local, x_local, y_true_one_hot_local):
+        logits_local = linear_classifier_predict(params_local, x_local)
+        log_probs_local = jax.nn.log_softmax(logits_local)
+        return -jnp.sum(log_probs_local * y_true_one_hot_local, axis=1).mean()
+
+    def accuracy(params_local, x_local, y_true_one_hot_local):
+        predictions_local = linear_classifier_predict(params_local, x_local)
+        predicted_classes_local = jnp.argmax(predictions_local, axis=1)
+        true_classes_local = jnp.argmax(y_true_one_hot_local, axis=1)
+        return jnp.mean(predicted_classes_local == true_classes_local)
+    # --- End Linear Classifier Components ---
+
+    all_probe_results = [] # To store (vode_idx, test_accuracy)
+
+    # --- Loop over Vode indices ---
+    for current_vode_idx in vode_indices_to_probe:
+        print(f"\n===== PROBING VODE INDEX: {current_vode_idx} =====")
+
+        # Ensure ./extracted_features directory exists for this Vode index if needed
+        # File paths inside extract_and_save_features and loading will use current_vode_idx
+        # The `extract_and_save_features` function will now need current_vode_idx
+
+        # 7. Extract features for train and test sets for the current_vode_idx
+        print(f"\n--- Extracting Features for Vode {current_vode_idx} ---")
+        extract_and_save_features(
+            train_loader, "train", model, optim_h_extractor, 
+            inference_steps_for_extraction, 
+            current_vode_idx, # Pass current Vode index
+            args.use_gap
+        )
+        extract_and_save_features(
+            test_loader, "test", model, optim_h_extractor, 
+            inference_steps_for_extraction, 
+            current_vode_idx, # Pass current Vode index
+            args.use_gap
+        )
+        print(f"\nFeature extraction for Vode {current_vode_idx} complete.")
+
+        # 8. Linear Classifier Training and Evaluation for current_vode_idx
+        print(f"\n--- Linear Classifier Training and Evaluation for Vode {current_vode_idx} ---")
+        
+        # Load the extracted features and labels for the current_vode_idx
+        train_features_path = os.path.join("./extracted_features", f"{args.config_name}_layer{current_vode_idx}_gap{args.use_gap}_train_features.npy")
+        train_labels_path = os.path.join("./extracted_features", f"{args.config_name}_layer{current_vode_idx}_gap{args.use_gap}_train_labels.npy")
+        test_features_path = os.path.join("./extracted_features", f"{args.config_name}_layer{current_vode_idx}_gap{args.use_gap}_test_features.npy")
+        test_labels_path = os.path.join("./extracted_features", f"{args.config_name}_layer{current_vode_idx}_gap{args.use_gap}_test_labels.npy")
+
+        try:
+            X_train_probe = np.load(train_features_path)
+            y_train_probe = np.load(train_labels_path)
+            X_test_probe = np.load(test_features_path)
+            y_test_probe = np.load(test_labels_path)
+        except FileNotFoundError:
+            print(f"Error: Feature files not found for Vode {current_vode_idx}. Please ensure feature extraction ran successfully.")
+            all_probe_results.append((current_vode_idx, "Error - Features not found"))
+            continue # Skip to next Vode index
+
+        print(f"Loaded training features for Vode {current_vode_idx}: {X_train_probe.shape}, labels: {y_train_probe.shape}")
+        print(f"Loaded test features for Vode {current_vode_idx}: {X_test_probe.shape}, labels: {y_test_probe.shape}")
+
+        # Initialize linear probe parameters (W, b)
+        num_features = X_train_probe.shape[1]
+        num_classes = 10 # For CIFAR-10
+        key_probe, W_key, b_key = jax.random.split(jax.random.PRNGKey(args.seed + current_vode_idx), 3) # Vary seed per Vode
+
+        probe_params = {
+            'W': jax.random.normal(W_key, (num_features, num_classes)) * 0.01,
+            'b': jnp.zeros(num_classes)
+        }
+
+        # One-hot encode labels for the probe
+        y_train_probe_one_hot = jax.nn.one_hot(y_train_probe, num_classes)
+        y_test_probe_one_hot = jax.nn.one_hot(y_test_probe, num_classes)
+
+        # Setup optimizer for the probe
+        probe_optimizer = optax.adamw(learning_rate=args.probe_lr, weight_decay=args.probe_wd)
+        opt_state_probe = probe_optimizer.init(probe_params)
+
+        print(f"Starting linear probe training for Vode {current_vode_idx}...")
+        probe_train_loader = DataLoader(
+            TensorDataset(torch.from_numpy(X_train_probe).float(), torch.from_numpy(np.asarray(y_train_probe_one_hot)).float()),
+            batch_size=args.probe_batch_size,
+            shuffle=True, # Shuffle training data for the probe
+            drop_last=True # Drop last if not a full batch
+        )
+
+        for epoch in range(args.probe_epochs):
+            epoch_train_loss = 0.0
+            num_batches_probe = 0
+            for X_batch_pt, y_batch_pt in probe_train_loader: # Use the probe_train_loader
+                X_batch_jax = jnp.array(X_batch_pt.numpy())
+                y_batch_jax = jnp.array(y_batch_pt.numpy())
+
+                loss_val, grads = jax.value_and_grad(cross_entropy_loss)(probe_params, X_batch_jax, y_batch_jax)
+                
+                updates, opt_state_probe = probe_optimizer.update(grads, opt_state_probe, probe_params)
+                probe_params = optax.apply_updates(probe_params, updates)
+
+                epoch_train_loss += loss_val
+                num_batches_probe += 1
+
+            avg_epoch_train_loss = epoch_train_loss / num_batches_probe
+            
+            # Calculate accuracy on the full training and test sets for the probe
+            # Ensure to use the original (non-batched, non-shuffled) NumPy versions for X and one-hot JAX arrays for y
+            epoch_train_acc = accuracy(probe_params, X_train_probe, np.asarray(y_train_probe_one_hot))
+            epoch_test_acc = accuracy(probe_params, X_test_probe, np.asarray(y_test_probe_one_hot))
+            
+            print(f"Vode {current_vode_idx} - Probe Epoch {epoch+1}/{args.probe_epochs} - Train Loss: {avg_epoch_train_loss:.4f}, Train Acc: {epoch_train_acc:.4f}, Test Acc: {epoch_test_acc:.4f}")
+        
+        # Evaluate the probe on the test set (final accuracy after all epochs)
+        final_test_acc = accuracy(probe_params, X_test_probe, np.asarray(y_test_probe_one_hot))
+        print(f"===== Vode {current_vode_idx} - Final Test Accuracy: {final_test_acc:.4f} =====")
+        all_probe_results.append((current_vode_idx, float(final_test_acc)))
+
+    # --- End Loop --- 
+
+    # Conditional post-extraction visualization
+    if args.feature_layer_vode_idx is not None: # Only run post-extraction viz if a specific Vode was targeted
+        # --- Add Post-Feature-Extraction Reconstruction Visualization ---
+        print("\n--- Generating Post-Feature-Extraction Reconstruction Visualization ---")
+        # We use the same vis_num_images, vis_fps, vis_image_shape as before.
+        # vis_target_T_values will be a list with a single element: the final step number.
+        vis_target_T_values = [inference_steps_for_extraction]
+        print(f"Visualization will use T_values: {vis_target_T_values} (derived from probe_inference_steps or its default)")
+
+        # Get a batch from the test_loader for visualization
+        try:
+            vis_batch_pt_full, vis_labels_pt_full = next(iter(test_loader))
+        except StopIteration:
+            print("Error: Could not get a batch from test_loader for visualization.")
+            vis_batch_pt_full = None
+
+        if vis_batch_pt_full is not None:
+            model.eval() # Ensure model is in eval mode
+            
+            post_all_images_all_recons_list = [] # To store [[img1_recons_steps], [img2_recons_steps]]
+            post_all_images_orig_for_video = []
+            post_all_images_labels_for_video = []
+            post_all_images_recon_loss = []
+
+            for i in range(vis_num_images):
+                print(f"Processing image {i+1}/{vis_num_images} for reconstruction video...")
+                single_image_np = vis_batch_pt_full[i:i+1].numpy() # Batch of 1 image
+                single_label_np = vis_labels_pt_full[i:i+1].numpy()
+
+                post_all_images_orig_for_video.append(single_image_np[0]) # Store unbatched image
+                post_all_images_labels_for_video.append(single_label_np[0])
+
+                recon_loss_single, single_img_all_recons_list, _, _ = unmask_on_batch_enhanced(
+                    use_corruption=False,
+                    corrupt_ratio=0.0,
+                    target_T_values=vis_target_T_values,
+                    x=jnp.array(single_image_np), # Pass single image as JAX array
+                    model=model,
+                    optim_h=optim_h_extractor,
+                    optim_w=None
+                )
+                post_all_images_all_recons_list.append(single_img_all_recons_list)
+                post_all_images_recon_loss.append(recon_loss_single)
+                print(f"  Reconstruction loss for image {i+1}: {recon_loss_single:.4f}")
+
+            if post_all_images_all_recons_list:
+                # create_reconstruction_video expects: List (num_images) of lists (T_steps) of reconstruction tensors.
+                # Each inner list (T_steps) should contain tensors of shape (1, C, H, W) or (C,H,W) if squeezed later.
+                # single_img_all_recons_list already contains [step0_recon_batch_of_1, step1_recon_batch_of_1, ...]
+                # So, post_all_images_all_recons_list is already in the correct format.
+                create_reconstruction_video(
+                    all_reconstruction_frames=post_all_images_all_recons_list,
+                    orig_images=post_all_images_orig_for_video,
+                    masked_images=post_all_images_orig_for_video, # Same as original for no corruption
+                    labels_list=post_all_images_labels_for_video,
+                    num_images=vis_num_images,
+                    image_shape=vis_image_shape,
+                    wandb_run=None, 
+                    epoch=None,     
+                    fps=vis_fps,
+                    reconstruction_mses=post_all_images_recon_loss 
+                )
+        # --- End Post-Feature-Extraction Reconstruction Visualization ---
+    else:
+        print("Skipping post-extraction reconstruction visualization because running in Vode sweep mode.")
+
+    # 9. Log all results
+    print("\n===== Linear Probe Sweep Results =====")
+    results_log_path = os.path.join("./results", f"linear_probe_sweep_{args.config_name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt")
+    os.makedirs("./results", exist_ok=True)
+
+    with open(results_log_path, 'w') as f:
+        f.write(f"Linear Probe Sweep Results - Model: {args.model_path}, Config: {args.config_name}\n")
+        f.write(f"Probe LR: {args.probe_lr}, Probe WD: {args.probe_wd}, Probe Epochs: {args.probe_epochs}\n")
+        f.write(f"Feature Extraction H LR: {h_inference_lr}, Feature Extraction Steps: {inference_steps_for_extraction}\n")
+        f.write(f"Global Average Pooling: {args.use_gap}\n\n")
+        f.write("Vode Index | Test Accuracy\n")
+        f.write("--------------------------\n")
+        for vode_idx, acc in sorted(all_probe_results, key=lambda item: item[1], reverse=True):
+            if isinstance(acc, str): # Handle error cases
+                f.write(f"{vode_idx:<10} | {acc}\n")
+                print(f"Vode {vode_idx}: {acc}")
+            else:
+                f.write(f"{vode_idx:<10} | {acc:.4f}\n")
+                print(f"Vode {vode_idx}: {acc:.4f}")
+    
+    print(f"\nResults saved to: {results_log_path}")
+
+    # Clean up: Remove feature files if desired (optional)
+    # print("\nCleaning up extracted feature files...")
+    # for current_vode_idx in vode_indices_to_probe:
+    #     for set_name in ["train", "test"]:
+    #         try:
+    #             features_path = os.path.join("./extracted_features", f"{args.config_name}_layer{current_vode_idx}_gap{args.use_gap}_{set_name}_features.npy")
+    #             labels_path = os.path.join("./extracted_features", f"{args.config_name}_layer{current_vode_idx}_gap{args.use_gap}_{set_name}_labels.npy")
+    #             os.remove(features_path)
+    #             os.remove(labels_path)
+    #         except OSError as e:
+    #             print(f"Error deleting file for Vode {current_vode_idx}, {set_name}: {e.strerror}")
+    # print("Cleanup complete.")
+
+if __name__ == "__main__":
+    main() 

--- a/examples/vision_transformer_script.py
+++ b/examples/vision_transformer_script.py
@@ -1,0 +1,369 @@
+import functools
+
+import einops  # https://github.com/arogozhnikov/einops
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import optax  # https://github.com/deepmind/optax
+
+# We'll use PyTorch to load the dataset.
+import torch
+import torchvision
+import torchvision.transforms as transforms
+from jaxtyping import Array, Float, PRNGKeyArray
+
+# Hyperparameters
+lr = 0.001
+dropout_rate = 0.0
+beta1 = 0.9
+beta2 = 0.999
+batch_size = 64
+patch_size = 4
+num_patches = 64
+num_steps = 50000  # Reduced for faster execution in script form, adjust as needed
+image_size = (32, 32, 3)
+embedding_dim = 64
+hidden_dim = 256
+num_heads = 1
+num_layers = 6
+height, width, channels = image_size
+num_classes = 10
+
+# Load CIFAR10 dataset
+transform_train = transforms.Compose(
+    [
+        transforms.RandomCrop(32, padding=4),
+        transforms.Resize((height, width)),
+        transforms.RandomHorizontalFlip(),
+        transforms.ToTensor(),
+        transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+    ]
+)
+
+transform_test = transforms.Compose(
+    [
+        transforms.Resize((height, width)),
+        transforms.ToTensor(),
+        transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+    ]
+)
+
+train_dataset = torchvision.datasets.CIFAR10(
+    "CIFAR",
+    train=True,
+    download=True,
+    transform=transform_train,
+)
+
+test_dataset = torchvision.datasets.CIFAR10(
+    "CIFAR",
+    train=False,
+    download=True,
+    transform=transform_test,
+)
+
+trainloader = torch.utils.data.DataLoader(
+    train_dataset, batch_size=batch_size, shuffle=True, drop_last=True
+)
+
+testloader = torch.utils.data.DataLoader(
+    test_dataset, batch_size=batch_size, shuffle=True, drop_last=True
+)
+
+# Patch embeddings layer
+class PatchEmbedding(eqx.Module):
+    linear: eqx.nn.Linear  # Corrected type annotation
+    patch_size: int
+
+    def __init__(
+        self,
+        input_channels: int,
+        output_shape: int,
+        patch_size: int,
+        key: PRNGKeyArray,
+    ):
+        self.patch_size = patch_size
+
+        self.linear = eqx.nn.Linear(
+            self.patch_size**2 * input_channels,
+            output_shape,
+            key=key,
+        )
+
+    def __call__(
+        self, x: Float[Array, "channels height width"]
+    ) -> Float[Array, "num_patches embedding_dim"]:
+        x = einops.rearrange(
+            x,
+            "c (h ph) (w pw) -> (h w) (c ph pw)",
+            ph=self.patch_size,
+            pw=self.patch_size,
+        )
+        x = jax.vmap(self.linear)(x)
+
+        return x
+
+# Attention block
+class AttentionBlock(eqx.Module):
+    layer_norm1: eqx.nn.LayerNorm
+    layer_norm2: eqx.nn.LayerNorm
+    attention: eqx.nn.MultiheadAttention
+    linear1: eqx.nn.Linear
+    linear2: eqx.nn.Linear
+    dropout1: eqx.nn.Dropout
+    dropout2: eqx.nn.Dropout
+
+    def __init__(
+        self,
+        input_shape: int,
+        hidden_dim: int,
+        num_heads: int,
+        dropout_rate: float,
+        key: PRNGKeyArray,
+    ):
+        key1, key2, key3 = jr.split(key, 3)
+
+        self.layer_norm1 = eqx.nn.LayerNorm(input_shape)
+        self.layer_norm2 = eqx.nn.LayerNorm(input_shape)
+        self.attention = eqx.nn.MultiheadAttention(num_heads, input_shape, key=key1)
+
+        self.linear1 = eqx.nn.Linear(input_shape, hidden_dim, key=key2)
+        self.linear2 = eqx.nn.Linear(hidden_dim, input_shape, key=key3)
+        self.dropout1 = eqx.nn.Dropout(dropout_rate)
+        self.dropout2 = eqx.nn.Dropout(dropout_rate)
+
+    def __call__(
+        self,
+        x: Float[Array, "num_patches embedding_dim"],
+        enable_dropout: bool,
+        key: PRNGKeyArray,
+    ) -> Float[Array, "num_patches embedding_dim"]:
+        input_x = jax.vmap(self.layer_norm1)(x)
+        x = x + self.attention(input_x, input_x, input_x, key=jr.fold_in(key, 0)) # Added key for attention
+
+        input_x = jax.vmap(self.layer_norm2)(x)
+        input_x = jax.vmap(self.linear1)(input_x)
+        input_x = jax.nn.gelu(input_x)
+
+        key1, key2 = jr.split(key, num=2)
+
+        input_x = self.dropout1(input_x, inference=not enable_dropout, key=key1)
+        input_x = jax.vmap(self.linear2)(input_x)
+        input_x = self.dropout2(input_x, inference=not enable_dropout, key=key2)
+
+        x = x + input_x
+
+        return x
+
+# Vision Transformer model
+class VisionTransformer(eqx.Module):
+    patch_embedding: PatchEmbedding
+    positional_embedding: jnp.ndarray
+    cls_token: jnp.ndarray
+    attention_blocks: list[AttentionBlock]
+    dropout: eqx.nn.Dropout
+    mlp: eqx.nn.Sequential
+    num_layers: int
+
+    def __init__(
+        self,
+        embedding_dim: int,
+        hidden_dim: int,
+        num_heads: int,
+        num_layers: int,
+        dropout_rate: float,
+        patch_size: int,
+        num_patches: int,
+        num_classes: int,
+        key: PRNGKeyArray,
+    ):
+        key1, key2, key3, key_att_blocks, key_mlp = jr.split(key, 5) # Renamed key4 to key_att_blocks, key5 to key_mlp
+
+        self.patch_embedding = PatchEmbedding(channels, embedding_dim, patch_size, key1)
+
+        self.positional_embedding = jr.normal(key2, (num_patches + 1, embedding_dim))
+
+        self.cls_token = jr.normal(key3, (1, embedding_dim))
+
+        self.num_layers = num_layers
+        
+        # Create keys for each attention block
+        attention_block_keys = jr.split(key_att_blocks, self.num_layers)
+        self.attention_blocks = [
+            AttentionBlock(embedding_dim, hidden_dim, num_heads, dropout_rate, attention_key) # Corrected typo
+            for attention_key in attention_block_keys # Corrected variable name and iteration
+        ]
+
+        self.dropout = eqx.nn.Dropout(dropout_rate)
+
+        self.mlp = eqx.nn.Sequential(
+            [
+                eqx.nn.LayerNorm(embedding_dim),
+                eqx.nn.Linear(embedding_dim, num_classes, key=key_mlp), # Use key_mlp
+            ]
+        )
+
+    def __call__(
+        self,
+        x: Float[Array, "channels height width"],
+        enable_dropout: bool,
+        key: PRNGKeyArray,
+    ) -> Float[Array, "num_classes"]:
+        x = self.patch_embedding(x)  # Output shape for single image: (num_patches, embedding_dim)
+
+        # Prepend the single CLS token (self.cls_token shape is (1, embedding_dim))
+        x = jnp.concatenate((self.cls_token, x), axis=0) # Shape: (1 + num_patches, embedding_dim)
+
+        x += self.positional_embedding[
+            : x.shape[0] # Slice positional embedding to match sequence length (1 + num_patches)
+        ]
+
+        dropout_key, *attention_keys = jr.split(key, num=self.num_layers + 1)
+
+        x = self.dropout(x, inference=not enable_dropout, key=dropout_key)
+
+        for block, attention_key_loop in zip(self.attention_blocks, attention_keys): # Renamed attention_key to attention_key_loop
+            x = block(x, enable_dropout, key=attention_key_loop)
+
+        # When __call__ processes a single instance (due to outer vmap):
+        # x shape is (1 + num_patches, embedding_dim)
+        cls_output = x[0]  # Select the CLS token. Shape: (embedding_dim,)
+        output = self.mlp(cls_output) # Apply MLP. Shape: (num_classes,)
+
+        return output
+
+# Gradient computation and training step
+@eqx.filter_value_and_grad
+def compute_grads(
+    model: VisionTransformer, images: jnp.ndarray, labels: jnp.ndarray, key: PRNGKeyArray
+):
+    # Keys for vmap need to be handled correctly.
+    # Assuming one key per batch item for the model call.
+    batch_keys = jr.split(key, images.shape[0])
+    logits = jax.vmap(model, in_axes=(0, None, 0))(images, True, batch_keys)
+    loss = optax.softmax_cross_entropy_with_integer_labels(logits, labels)
+    return jnp.mean(loss)
+
+
+@eqx.filter_jit
+def step_model(
+    model: VisionTransformer,
+    optimizer: optax.GradientTransformation,
+    state: optax.OptState,
+    images: jnp.ndarray,
+    labels: jnp.ndarray,
+    key: PRNGKeyArray, # Single key for the step
+):
+    loss, grads = compute_grads(model, images, labels, key) # Pass the single key
+    updates, new_state = optimizer.update(grads, state, model)
+    model = eqx.apply_updates(model, updates)
+    return model, new_state, loss
+
+
+def train(
+    model: VisionTransformer,
+    optimizer: optax.GradientTransformation,
+    state: optax.OptState,
+    data_loader: torch.utils.data.DataLoader,
+    num_steps: int,
+    print_every: int = 1000,
+    key: PRNGKeyArray = None, # Default to None
+):
+    if key is None:
+        key = jr.PRNGKey(0) # Default key if not provided
+
+    losses = []
+    data_iter = iter(data_loader) # Use a direct iterator
+
+    for step in range(num_steps):
+        try:
+            images, labels = next(data_iter)
+        except StopIteration: # Reset iterator if dataset is exhausted
+            data_iter = iter(data_loader)
+            images, labels = next(data_iter)
+
+
+        images = images.numpy()
+        labels = labels.numpy()
+
+        step_key, key = jr.split(key) # Split key for the current step
+
+        model, state, loss = step_model(
+            model, optimizer, state, images, labels, step_key # Use step_key
+        )
+
+        losses.append(loss.item()) # .item() to get scalar
+
+        if (step % print_every) == 0 or step == num_steps - 1:
+            print(f"Step: {step}/{num_steps}, Loss: {loss.item()}.")
+
+    return model, state, losses
+
+# Main execution block
+if __name__ == "__main__":
+    key = jr.PRNGKey(2003)
+    model_key, train_key, eval_key = jr.split(key, 3)
+
+
+    model = VisionTransformer(
+        embedding_dim=embedding_dim,
+        hidden_dim=hidden_dim,
+        num_heads=num_heads,
+        num_layers=num_layers,
+        dropout_rate=dropout_rate,
+        patch_size=patch_size,
+        num_patches=num_patches,
+        num_classes=num_classes,
+        key=model_key, # Use model_key
+    )
+
+    optimizer = optax.adamw(
+        learning_rate=lr,
+        b1=beta1,
+        b2=beta2,
+    )
+
+    state = optimizer.init(eqx.filter(model, eqx.is_inexact_array))
+
+    print("Starting training...")
+    model, state, losses = train(model, optimizer, state, trainloader, num_steps, key=train_key) # Use train_key
+    print("Training finished.")
+
+    # Evaluation
+    print("Starting evaluation...")
+    accuracies = []
+    
+    eval_data_iter = iter(testloader)
+    num_eval_batches = len(test_dataset) // batch_size
+
+    for _ in range(num_eval_batches): # Iterate a fixed number of batches
+        try:
+            images, labels = next(eval_data_iter)
+        except StopIteration:
+            # This shouldn't happen if num_eval_batches is correct
+            print("Warning: Test loader exhausted prematurely.")
+            break 
+
+        images_np = images.numpy()
+        labels_np = labels.numpy()
+        
+        # Create keys for each image in the batch for the model call during evaluation
+        batch_eval_keys = jr.split(eval_key, images_np.shape[0])
+        eval_key, _ = jr.split(eval_key) # Consume the key by splitting
+
+        logits = jax.vmap(model, in_axes=(0, None, 0))(
+            images_np, False, batch_eval_keys
+        )
+
+        predictions = jnp.argmax(logits, axis=-1)
+        accuracy = jnp.mean(predictions == labels_np)
+        accuracies.append(accuracy.item()) # .item() to get scalar
+
+    if accuracies:
+        avg_accuracy = np.mean(accuracies) * 100
+        print(f"Average Accuracy: {avg_accuracy:.2f}%")
+    else:
+        print("No accuracies calculated.")
+    print("Evaluation finished.") 

--- a/results/hyperparam_search_results/hyperparam_search_results_6block_20250522_134927.txt
+++ b/results/hyperparam_search_results/hyperparam_search_results_6block_20250522_134927.txt
@@ -1,0 +1,43 @@
+Hyperparameter Search Log - 2025-05-22 13:49:27
+Base Config for non-searched params: 6block
+Fixed Overrides (excluding searched params):
+  epochs: 75
+  theta: 100
+  test_subset: 200
+  peak_lr_weights: 0.001
+  hidden_lr_inference: 0.095
+  reconstruction_every_n_epochs: 75
+  validation_every_n_epochs: 75
+  use_inference_lr_scaling: True
+  use_lr_schedule_w: True
+  use_lr_schedule_h: True
+  weight_decay: 0.0002
+  mlp_ratio: 4.0
+  patch_size: 4
+  use_noise: True
+  update_weights_every_inference_step: False
+  use_early_stopping: True
+  early_stopping_patience: 7
+  early_stopping_min_delta: 0.001
+  use_vode_grad_norm: False
+  use_adamw_for_hidden_optimizer: False
+  corrupt_ratio: 0.25
+  use_lower_half_mask: False
+  inference_clamp_alpha: 1.0
+  save_reconstruction_images: True
+  save_reconstruction_video: True
+  video_fps: 5
+  reinitialize_model_for_each_epoch: False
+  use_status_init_in_training: False
+  use_status_init_in_unmasking: False
+  lr_schedule_min_lr_factor: 0.5
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Run | NB | BS   | HS   | NH | VodeLN | LR Hid    | Scale   | Inf Steps | Warmup | Hid Mom | H Clip | W Clip | Seed | Best Val MSE   | Run Best Train MSE | Final Train MSE | Status   | W&B Run Name                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+1   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 42   | 0.02694218     | 0.00594851         | 0.01030183      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd42
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Best Params: num_blocks=6, batch_size=200, hidden_size=64, num_heads=1, use_vode_state_layernorm=OFF, peak_lr_hidden=9.500e-02, inference_lr_scale_base=1.25, inference_steps=20, warmup_steps=0, hidden_momentum=0.40, h_grad_clip_norm=2000.0, w_grad_clip_norm=500.0, seed=42
+Achieved Overall Best Validation MSE: 0.026942
+Run Best Train MSE of Best Val Run: 0.005948510952293873
+Final Train MSE of Best Val Run: 0.010301830247044563
+ (lr_weights=1.000e-03 fixed)

--- a/results/hyperparam_search_results/hyperparam_search_results_6block_20250522_152231.txt
+++ b/results/hyperparam_search_results/hyperparam_search_results_6block_20250522_152231.txt
@@ -1,0 +1,46 @@
+Hyperparameter Search Log - 2025-05-22 15:22:31
+Base Config for non-searched params: 6block
+Fixed Overrides (excluding searched params):
+  epochs: 75
+  theta: 100
+  num_images: 10
+  test_subset: 200
+  peak_lr_weights: 0.001
+  hidden_lr_inference: 0.095
+  reconstruction_every_n_epochs: 75
+  validation_every_n_epochs: 75
+  use_inference_lr_scaling: True
+  use_lr_schedule_w: True
+  use_lr_schedule_h: True
+  weight_decay: 0.0002
+  mlp_ratio: 4.0
+  patch_size: 4
+  use_noise: True
+  update_weights_every_inference_step: False
+  use_early_stopping: True
+  early_stopping_patience: 7
+  early_stopping_min_delta: 0.001
+  use_vode_grad_norm: False
+  use_adamw_for_hidden_optimizer: False
+  corrupt_ratio: 0.25
+  use_lower_half_mask: False
+  inference_clamp_alpha: 1.0
+  save_reconstruction_images: True
+  save_reconstruction_video: True
+  video_fps: 5
+  reinitialize_model_for_each_epoch: False
+  use_status_init_in_training: False
+  use_status_init_in_unmasking: False
+  lr_schedule_min_lr_factor: 0.5
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Run | NB | BS   | HS   | NH | VodeLN | LR Hid    | Scale   | Inf Steps | Warmup | Hid Mom | H Clip | W Clip | Seed | Best Val MSE   | Run Best Train MSE | Final Train MSE | Status   | W&B Run Name                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+1   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 100  | 0.00420657     | 0.00505749         | 0.01315031      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd100
+2   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 80   | 0.00457702     | 0.00739025         | 0.01641586      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd80
+3   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 90   | 0.00933725     | 0.01580290         | 0.01993874      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd90
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Best Params: num_blocks=6, batch_size=200, hidden_size=64, num_heads=1, use_vode_state_layernorm=OFF, peak_lr_hidden=9.500e-02, inference_lr_scale_base=1.25, inference_steps=20, warmup_steps=0, hidden_momentum=0.40, h_grad_clip_norm=2000.0, w_grad_clip_norm=500.0, seed=100
+Achieved Overall Best Validation MSE: 0.004207
+Run Best Train MSE of Best Val Run: 0.0050574904307723045
+Final Train MSE of Best Val Run: 0.013150305487215519
+ (lr_weights=1.000e-03 fixed)

--- a/results/hyperparam_search_results/hyperparam_search_results_6block_20250523_083624.txt
+++ b/results/hyperparam_search_results/hyperparam_search_results_6block_20250523_083624.txt
@@ -1,0 +1,48 @@
+Hyperparameter Search Log - 2025-05-23 08:36:24
+Base Config for non-searched params: 6block
+Fixed Overrides (excluding searched params):
+  epochs: 75
+  theta: 10000
+  use_ssl_augmentations: True
+  num_images: 10
+  test_subset: 200
+  peak_lr_weights: 0.001
+  hidden_lr_inference: 0.095
+  reconstruction_every_n_epochs: 75
+  validation_every_n_epochs: 10
+  use_inference_lr_scaling: True
+  use_lr_schedule_w: True
+  use_lr_schedule_h: True
+  weight_decay: 0.0002
+  mlp_ratio: 4.0
+  patch_size: 4
+  use_noise: True
+  update_weights_every_inference_step: False
+  use_early_stopping: True
+  early_stopping_patience: 10
+  early_stopping_min_delta: 0.001
+  early_stopping_metric: train_mse
+  use_vode_grad_norm: False
+  use_adamw_for_hidden_optimizer: False
+  corrupt_ratio: 0.25
+  use_lower_half_mask: False
+  inference_clamp_alpha: 1.0
+  save_reconstruction_images: True
+  save_reconstruction_video: True
+  video_fps: 5
+  reinitialize_model_for_each_epoch: False
+  use_status_init_in_training: False
+  use_status_init_in_unmasking: False
+  lr_schedule_min_lr_factor: 0.5
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Run | NB | BS   | HS   | NH | VodeLN | LR Hid    | Scale   | Inf Steps | Warmup | Hid Mom | H Clip | W Clip | Seed | Best Val MSE   | Run Best Train MSE | Final Train MSE | Status   | W&B Run Name                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+3   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 90   | 0.01659267     | 0.00626575         | 0.03715212      |          | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd90
+2   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 80   | 0.02460983     | 0.01978706         | 0.04791573      |          | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd80
+1   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 100  | 0.03871263     | 0.02960836         | 0.06313047      |          | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd100
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Best Params: num_blocks=6, batch_size=200, hidden_size=64, num_heads=1, use_vode_state_layernorm=OFF, peak_lr_hidden=9.500e-02, inference_lr_scale_base=1.25, inference_steps=20, warmup_steps=0, hidden_momentum=0.40, h_grad_clip_norm=2000.0, w_grad_clip_norm=500.0, seed=90
+Achieved Overall Best Validation MSE: 0.016593
+Run Best Train MSE of Best Val Run: 0.0062657492235302925
+Final Train MSE of Best Val Run: 0.037152115255594254
+ (lr_weights=1.000e-03 fixed)

--- a/results/hyperparam_search_results/hyperparam_search_results_6block_20250523_093235.txt
+++ b/results/hyperparam_search_results/hyperparam_search_results_6block_20250523_093235.txt
@@ -1,0 +1,48 @@
+Hyperparameter Search Log - 2025-05-23 09:32:35
+Base Config for non-searched params: 6block
+Fixed Overrides (excluding searched params):
+  epochs: 75
+  theta: 10000
+  use_ssl_augmentations: True
+  num_images: 10
+  test_subset: 200
+  peak_lr_weights: 0.001
+  hidden_lr_inference: 0.095
+  reconstruction_every_n_epochs: 75
+  validation_every_n_epochs: 10
+  use_inference_lr_scaling: True
+  use_lr_schedule_w: True
+  use_lr_schedule_h: True
+  weight_decay: 0.0002
+  mlp_ratio: 4.0
+  patch_size: 4
+  use_noise: True
+  update_weights_every_inference_step: False
+  use_early_stopping: True
+  early_stopping_patience: 20
+  early_stopping_min_delta: 0.001
+  early_stopping_metric: train_mse
+  use_vode_grad_norm: False
+  use_adamw_for_hidden_optimizer: False
+  corrupt_ratio: 0.25
+  use_lower_half_mask: False
+  inference_clamp_alpha: 1.0
+  save_reconstruction_images: True
+  save_reconstruction_video: True
+  video_fps: 5
+  reinitialize_model_for_each_epoch: False
+  use_status_init_in_training: False
+  use_status_init_in_unmasking: False
+  lr_schedule_min_lr_factor: 0.5
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Run | NB | BS   | HS   | NH | VodeLN | LR Hid    | Scale   | Inf Steps | Warmup | Hid Mom | H Clip | W Clip | Seed | Best Val MSE   | Run Best Train MSE | Final Train MSE | Status   | W&B Run Name                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+2   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 80   | 0.01508223     | 0.01942340         | 0.02588100      |          | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd80
+3   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 90   | 0.03046750     | 0.03714596         | 0.03714596      |          | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd90
+1   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 100  | 0.03467868     | 0.04527521         | 0.04863636      |          | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd100
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Best Params: num_blocks=6, batch_size=200, hidden_size=64, num_heads=1, use_vode_state_layernorm=OFF, peak_lr_hidden=9.500e-02, inference_lr_scale_base=1.25, inference_steps=20, warmup_steps=0, hidden_momentum=0.40, h_grad_clip_norm=2000.0, w_grad_clip_norm=500.0, seed=80
+Achieved Overall Best Validation MSE: 0.015082
+Run Best Train MSE of Best Val Run: 0.01942340098321438
+Final Train MSE of Best Val Run: 0.025880999863147736
+ (lr_weights=1.000e-03 fixed)

--- a/results/hyperparam_search_results/hyperparam_search_results_6block_20250523_134529.txt
+++ b/results/hyperparam_search_results/hyperparam_search_results_6block_20250523_134529.txt
@@ -1,0 +1,56 @@
+Hyperparameter Search Log - 2025-05-23 13:45:29
+Base Config for non-searched params: 6block
+Fixed Overrides (excluding searched params):
+  epochs: 75
+  theta: 10000
+  use_ssl_augmentations: True
+  use_cifar10_norm: True
+  num_images: 10
+  test_subset: 200
+  peak_lr_weights: 0.001
+  hidden_lr_inference: 0.095
+  reconstruction_every_n_epochs: 75
+  validation_every_n_epochs: 10
+  use_inference_lr_scaling: True
+  use_lr_schedule_w: True
+  use_lr_schedule_h: True
+  weight_decay: 0.0002
+  mlp_ratio: 4.0
+  patch_size: 4
+  use_noise: True
+  update_weights_every_inference_step: False
+  use_early_stopping: True
+  early_stopping_patience: 50
+  early_stopping_min_delta: 0.001
+  early_stopping_metric: train_mse
+  use_vode_grad_norm: False
+  use_adamw_for_hidden_optimizer: False
+  corrupt_ratio: 0.25
+  use_lower_half_mask: False
+  inference_clamp_alpha: 1.0
+  save_reconstruction_images: True
+  save_reconstruction_video: True
+  video_fps: 5
+  reinitialize_model_for_each_epoch: False
+  use_status_init_in_training: False
+  use_status_init_in_unmasking: False
+  lr_schedule_min_lr_factor: 0.5
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Run | NB | BS   | HS   | NH | VodeLN | LR Hid    | Scale   | Inf Steps | Warmup | Hid Mom | H Clip | W Clip | Seed | Best Val MSE   | Run Best Train MSE | Final Train MSE | Status   | W&B Run Name                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+3   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 90   | 0.01423427     | 0.01359762         | 0.01885515      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd90
+7   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 40   | 0.01565210     | 0.02491640         | 0.08362384      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd40
+8   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 30   | 0.01920341     | 0.02283833         | 0.05846124      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd30
+1   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 100  | 0.02452417     | 0.01924552         | 0.23620826      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd100
+6   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 50   | 0.02712068     | 0.02767810         | 0.05016486      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd50
+2   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 80   | 0.03303562     | 0.03237247         | 0.16974296      |          | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd80
+5   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 60   | 0.03425604     | 0.03073064         | 0.46605662      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd60
+9   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 20   | 0.03597884     | 0.04939213         | 0.20095292      |          | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd20
+4   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 70   | 0.03972095     | 0.03620780         | 0.40641153      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd70
+10  | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 10   | 0.05018316     | 0.06059325         | 0.31624240      |          | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd10
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Best Params: num_blocks=6, batch_size=200, hidden_size=64, num_heads=1, use_vode_state_layernorm=OFF, peak_lr_hidden=9.500e-02, inference_lr_scale_base=1.25, inference_steps=20, warmup_steps=0, hidden_momentum=0.40, h_grad_clip_norm=2000.0, w_grad_clip_norm=500.0, seed=90
+Achieved Overall Best Validation MSE: 0.014234
+Run Best Train MSE of Best Val Run: 0.013597618788480759
+Final Train MSE of Best Val Run: 0.018855150789022446
+ (lr_weights=1.000e-03 fixed)

--- a/results/hyperparam_search_results/hyperparam_search_results_6block_20250523_143954.txt
+++ b/results/hyperparam_search_results/hyperparam_search_results_6block_20250523_143954.txt
@@ -1,0 +1,47 @@
+Hyperparameter Search Log - 2025-05-23 14:39:54
+Base Config for non-searched params: 6block
+Fixed Overrides (excluding searched params):
+  epochs: 75
+  theta: 100
+  use_ssl_augmentations: False
+  use_cifar10_norm: False
+  num_images: 10
+  test_subset: 200
+  peak_lr_weights: 0.001
+  hidden_lr_inference: 0.095
+  reconstruction_every_n_epochs: 25
+  validation_every_n_epochs: 10
+  use_inference_lr_scaling: True
+  use_lr_schedule_w: True
+  use_lr_schedule_h: True
+  weight_decay: 0.0002
+  mlp_ratio: 4.0
+  patch_size: 4
+  use_noise: True
+  update_weights_every_inference_step: False
+  use_early_stopping: True
+  early_stopping_patience: 50
+  early_stopping_min_delta: 0.001
+  early_stopping_metric: train_mse
+  use_vode_grad_norm: False
+  use_adamw_for_hidden_optimizer: False
+  corrupt_ratio: 0.25
+  use_lower_half_mask: False
+  inference_clamp_alpha: 1.0
+  save_reconstruction_images: True
+  save_reconstruction_video: True
+  video_fps: 5
+  reinitialize_model_for_each_epoch: False
+  use_status_init_in_training: False
+  use_status_init_in_unmasking: False
+  lr_schedule_min_lr_factor: 0.5
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Run | NB | BS   | HS   | NH | VodeLN | LR Hid    | Scale   | Inf Steps | Warmup | Hid Mom | H Clip | W Clip | Seed | Best Val MSE   | Run Best Train MSE | Final Train MSE | Status   | W&B Run Name                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+1   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 100  | 0.00911733     | 0.00846103         | 0.02151206      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd100
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Best Params: num_blocks=6, batch_size=200, hidden_size=64, num_heads=1, use_vode_state_layernorm=OFF, peak_lr_hidden=9.500e-02, inference_lr_scale_base=1.25, inference_steps=20, warmup_steps=0, hidden_momentum=0.40, h_grad_clip_norm=2000.0, w_grad_clip_norm=500.0, seed=100
+Achieved Overall Best Validation MSE: 0.009117
+Run Best Train MSE of Best Val Run: 0.008461029268801212
+Final Train MSE of Best Val Run: 0.02151205576956272
+ (lr_weights=1.000e-03 fixed)

--- a/results/hyperparam_search_results/hyperparam_search_results_6block_20250523_182743.txt
+++ b/results/hyperparam_search_results/hyperparam_search_results_6block_20250523_182743.txt
@@ -1,0 +1,55 @@
+Hyperparameter Search Log - 2025-05-23 18:27:43
+Base Config for non-searched params: 6block
+Fixed Overrides (excluding searched params):
+  epochs: 75
+  theta: 100
+  use_ssl_augmentations: False
+  use_cifar10_norm: False
+  num_images: 10
+  test_subset: 200
+  peak_lr_weights: 0.001
+  hidden_lr_inference: 0.095
+  reconstruction_every_n_epochs: 75
+  validation_every_n_epochs: 75
+  use_inference_lr_scaling: True
+  use_lr_schedule_w: True
+  use_lr_schedule_h: True
+  weight_decay: 0.0002
+  mlp_ratio: 4.0
+  patch_size: 4
+  use_noise: True
+  update_weights_every_inference_step: False
+  use_early_stopping: True
+  early_stopping_patience: 50
+  early_stopping_min_delta: 0.001
+  early_stopping_metric: train_mse
+  save_model_train_mse_threshold: 0.009
+  model_saving_metric: train_mse
+  use_vode_grad_norm: False
+  use_adamw_for_hidden_optimizer: False
+  corrupt_ratio: 0.25
+  use_lower_half_mask: False
+  inference_clamp_alpha: 1.0
+  save_reconstruction_images: True
+  save_reconstruction_video: True
+  video_fps: 5
+  reinitialize_model_for_each_epoch: False
+  use_status_init_in_training: False
+  use_status_init_in_unmasking: False
+  lr_schedule_min_lr_factor: 0.5
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Run | NB | BS   | HS   | NH | VodeLN | LR Hid    | Scale   | Inf Steps | Warmup | Hid Mom | H Clip | W Clip | Seed | Best Val MSE   | Run Best Train MSE | Final Train MSE | Status   | W&B Run Name                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+5   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 80   | 0.00453624     | 0.00453122         | 0.00535501      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd80
+6   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 90   | 0.00498547     | 0.00563026         | 0.01436575      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd90
+2   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 50   | 0.00578588     | 0.01107579         | 0.01442510      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd50
+1   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 40   | 0.00782853     | 0.00764948         | 0.03138233      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd40
+3   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 60   | 0.00805525     | 0.00793299         | 0.05106462      | (Done)   | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd60
+7   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 100  | Failed or Invalid | 0.01321342         | 0.04187635      | (ValFail) | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd100
+4   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 70   | Failed or Invalid | 0.01850187         | 0.04725964      | (ValFail) | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd70
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Best Params: num_blocks=6, batch_size=200, hidden_size=64, num_heads=1, use_vode_state_layernorm=OFF, peak_lr_hidden=9.500e-02, inference_lr_scale_base=1.25, inference_steps=20, warmup_steps=0, hidden_momentum=0.40, h_grad_clip_norm=2000.0, w_grad_clip_norm=500.0, seed=80
+Achieved Overall Best Validation MSE: 0.004536
+Run Best Train MSE of Best Val Run: 0.004531223326921463
+Final Train MSE of Best Val Run: 0.005355013534426689
+ (lr_weights=1.000e-03 fixed)

--- a/results/hyperparam_search_results/hyperparam_search_results_6block_20250523_211850.txt
+++ b/results/hyperparam_search_results/hyperparam_search_results_6block_20250523_211850.txt
@@ -1,0 +1,49 @@
+Hyperparameter Search Log - 2025-05-23 21:18:50
+Base Config for non-searched params: 6block
+Fixed Overrides (excluding searched params):
+  epochs: 150
+  theta: 100
+  use_ssl_augmentations: False
+  use_cifar10_norm: False
+  num_images: 10
+  test_subset: 200
+  peak_lr_weights: 0.001
+  hidden_lr_inference: 0.095
+  reconstruction_every_n_epochs: 75
+  validation_every_n_epochs: 75
+  use_inference_lr_scaling: True
+  use_lr_schedule_w: True
+  use_lr_schedule_h: True
+  weight_decay: 0.0002
+  mlp_ratio: 4.0
+  patch_size: 4
+  use_noise: True
+  update_weights_every_inference_step: False
+  use_early_stopping: True
+  early_stopping_patience: 50
+  early_stopping_min_delta: 0.001
+  early_stopping_metric: train_mse
+  save_model_train_mse_threshold: 0.009
+  model_saving_metric: train_mse
+  use_vode_grad_norm: False
+  use_adamw_for_hidden_optimizer: False
+  corrupt_ratio: 0.25
+  use_lower_half_mask: False
+  inference_clamp_alpha: 1.0
+  save_reconstruction_images: True
+  save_reconstruction_video: True
+  video_fps: 5
+  reinitialize_model_for_each_epoch: False
+  use_status_init_in_training: False
+  use_status_init_in_unmasking: False
+  lr_schedule_min_lr_factor: 0
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Run | NB | BS   | HS   | NH | VodeLN | LR Hid    | Scale   | Inf Steps | Warmup | Hid Mom | H Clip | W Clip | Seed | Best Val MSE   | Run Best Train MSE | Final Train MSE | Status   | W&B Run Name                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+1   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 80   | 0.01026478     | 0.01033121         | 0.01892012      |          | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd80
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Best Params: num_blocks=6, batch_size=200, hidden_size=64, num_heads=1, use_vode_state_layernorm=OFF, peak_lr_hidden=9.500e-02, inference_lr_scale_base=1.25, inference_steps=20, warmup_steps=0, hidden_momentum=0.40, h_grad_clip_norm=2000.0, w_grad_clip_norm=500.0, seed=80
+Achieved Overall Best Validation MSE: 0.010265
+Run Best Train MSE of Best Val Run: 0.010331209748983383
+Final Train MSE of Best Val Run: 0.01892011985182762
+ (lr_weights=1.000e-03 fixed)

--- a/results/hyperparam_search_results/hyperparam_search_results_6block_20250523_220008.txt
+++ b/results/hyperparam_search_results/hyperparam_search_results_6block_20250523_220008.txt
@@ -1,0 +1,49 @@
+Hyperparameter Search Log - 2025-05-23 22:00:08
+Base Config for non-searched params: 6block
+Fixed Overrides (excluding searched params):
+  epochs: 150
+  theta: 100
+  use_ssl_augmentations: False
+  use_cifar10_norm: False
+  num_images: 10
+  test_subset: 200
+  peak_lr_weights: 0.0001
+  hidden_lr_inference: 0.095
+  reconstruction_every_n_epochs: 75
+  validation_every_n_epochs: 75
+  use_inference_lr_scaling: True
+  use_lr_schedule_w: True
+  use_lr_schedule_h: True
+  weight_decay: 0.0002
+  mlp_ratio: 4.0
+  patch_size: 4
+  use_noise: True
+  update_weights_every_inference_step: False
+  use_early_stopping: True
+  early_stopping_patience: 50
+  early_stopping_min_delta: 0.001
+  early_stopping_metric: train_mse
+  save_model_train_mse_threshold: 0.009
+  model_saving_metric: train_mse
+  use_vode_grad_norm: False
+  use_adamw_for_hidden_optimizer: False
+  corrupt_ratio: 0.25
+  use_lower_half_mask: False
+  inference_clamp_alpha: 1.0
+  save_reconstruction_images: True
+  save_reconstruction_video: True
+  video_fps: 5
+  reinitialize_model_for_each_epoch: False
+  use_status_init_in_training: False
+  use_status_init_in_unmasking: False
+  lr_schedule_min_lr_factor: 0.5
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Run | NB | BS   | HS   | NH | VodeLN | LR Hid    | Scale   | Inf Steps | Warmup | Hid Mom | H Clip | W Clip | Seed | Best Val MSE   | Run Best Train MSE | Final Train MSE | Status   | W&B Run Name                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+1   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 80   | 0.03421651     | 0.01733242         | 0.01884712      |          | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd80
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Best Params: num_blocks=6, batch_size=200, hidden_size=64, num_heads=1, use_vode_state_layernorm=OFF, peak_lr_hidden=9.500e-02, inference_lr_scale_base=1.25, inference_steps=20, warmup_steps=0, hidden_momentum=0.40, h_grad_clip_norm=2000.0, w_grad_clip_norm=500.0, seed=80
+Achieved Overall Best Validation MSE: 0.034217
+Run Best Train MSE of Best Val Run: 0.017332421615719795
+Final Train MSE of Best Val Run: 0.01884712092578411
+ (lr_weights=1.000e-04 fixed)

--- a/results/hyperparam_search_results/hyperparam_search_results_6block_20250523_223627.txt
+++ b/results/hyperparam_search_results/hyperparam_search_results_6block_20250523_223627.txt
@@ -1,0 +1,49 @@
+Hyperparameter Search Log - 2025-05-23 22:36:27
+Base Config for non-searched params: 6block
+Fixed Overrides (excluding searched params):
+  epochs: 150
+  theta: 100
+  use_ssl_augmentations: True
+  use_cifar10_norm: True
+  num_images: 10
+  test_subset: 200
+  peak_lr_weights: 0.0001
+  hidden_lr_inference: 0.095
+  reconstruction_every_n_epochs: 75
+  validation_every_n_epochs: 75
+  use_inference_lr_scaling: True
+  use_lr_schedule_w: True
+  use_lr_schedule_h: True
+  weight_decay: 0.0002
+  mlp_ratio: 4.0
+  patch_size: 4
+  use_noise: True
+  update_weights_every_inference_step: False
+  use_early_stopping: True
+  early_stopping_patience: 50
+  early_stopping_min_delta: 0.001
+  early_stopping_metric: train_mse
+  save_model_train_mse_threshold: 0.009
+  model_saving_metric: train_mse
+  use_vode_grad_norm: False
+  use_adamw_for_hidden_optimizer: False
+  corrupt_ratio: 0.25
+  use_lower_half_mask: False
+  inference_clamp_alpha: 1.0
+  save_reconstruction_images: True
+  save_reconstruction_video: True
+  video_fps: 5
+  reinitialize_model_for_each_epoch: False
+  use_status_init_in_training: False
+  use_status_init_in_unmasking: False
+  lr_schedule_min_lr_factor: 0.5
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Run | NB | BS   | HS   | NH | VodeLN | LR Hid    | Scale   | Inf Steps | Warmup | Hid Mom | H Clip | W Clip | Seed | Best Val MSE   | Run Best Train MSE | Final Train MSE | Status   | W&B Run Name                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+1   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 80   | 0.04677085     | 0.04008760         | 0.04529755      |          | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd80
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Best Params: num_blocks=6, batch_size=200, hidden_size=64, num_heads=1, use_vode_state_layernorm=OFF, peak_lr_hidden=9.500e-02, inference_lr_scale_base=1.25, inference_steps=20, warmup_steps=0, hidden_momentum=0.40, h_grad_clip_norm=2000.0, w_grad_clip_norm=500.0, seed=80
+Achieved Overall Best Validation MSE: 0.046771
+Run Best Train MSE of Best Val Run: 0.04008759558200836
+Final Train MSE of Best Val Run: 0.04529755190014839
+ (lr_weights=1.000e-04 fixed)

--- a/results/hyperparam_search_results/hyperparam_search_results_6block_20250524_014756.txt
+++ b/results/hyperparam_search_results/hyperparam_search_results_6block_20250524_014756.txt
@@ -1,0 +1,53 @@
+Hyperparameter Search Log - 2025-05-24 01:47:56
+Base Config for non-searched params: 6block
+Fixed Overrides (excluding searched params):
+  epochs: 150
+  theta: 10000
+  use_ssl_augmentations: True
+  use_cifar10_norm: True
+  num_images: 10
+  test_subset: 200
+  peak_lr_weights: 0.0001
+  hidden_lr_inference: 0.095
+  reconstruction_every_n_epochs: 75
+  validation_every_n_epochs: 75
+  use_inference_lr_scaling: True
+  use_lr_schedule_w: True
+  use_lr_schedule_h: True
+  weight_decay: 0.0002
+  mlp_ratio: 4.0
+  patch_size: 4
+  use_noise: True
+  update_weights_every_inference_step: True
+  use_early_stopping: True
+  early_stopping_patience: 50
+  early_stopping_min_delta: 0.001
+  early_stopping_metric: train_mse
+  save_model_train_mse_threshold: 0.009
+  model_saving_metric: train_mse
+  use_vode_grad_norm: False
+  use_adamw_for_hidden_optimizer: False
+  corrupt_ratio: 0.25
+  use_lower_half_mask: False
+  inference_clamp_alpha: 1.0
+  save_reconstruction_images: True
+  save_reconstruction_video: True
+  video_fps: 5
+  reinitialize_model_for_each_epoch: False
+  use_status_init_in_training: True
+  use_status_init_in_unmasking: True
+  lr_schedule_min_lr_factor: 0.5
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Run | NB | BS   | HS   | NH | VodeLN | LR Hid    | Scale   | Inf Steps | Warmup | Hid Mom | H Clip | W Clip | Seed | Best Val MSE   | Run Best Train MSE | Final Train MSE | Status   | W&B Run Name                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+5   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 120  | 0.45600668     | 0.35317740         | 0.42486140      |          | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd120
+1   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 80   | Failed or Invalid | 0.32305232         | 0.44857344      | (ValFail) | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd80
+4   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 110  | Failed or Invalid | 0.34258980         | 0.34448269      | (ValFail) | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd110
+2   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 90   | Failed or Invalid | 0.35752723         | 0.45041817      | (ValFail) | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd90
+3   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 100  | Failed or Invalid | 0.39902470         | 0.42747700      | (ValFail) | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd100
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Best Params: num_blocks=6, batch_size=200, hidden_size=64, num_heads=1, use_vode_state_layernorm=OFF, peak_lr_hidden=9.500e-02, inference_lr_scale_base=1.25, inference_steps=20, warmup_steps=0, hidden_momentum=0.40, h_grad_clip_norm=2000.0, w_grad_clip_norm=500.0, seed=120
+Achieved Overall Best Validation MSE: 0.456007
+Run Best Train MSE of Best Val Run: 0.35317739844322205
+Final Train MSE of Best Val Run: 0.4248614013195038
+ (lr_weights=1.000e-04 fixed)

--- a/results/hyperparam_search_results/hyperparam_search_results_6block_20250524_103528.txt
+++ b/results/hyperparam_search_results/hyperparam_search_results_6block_20250524_103528.txt
@@ -1,0 +1,54 @@
+Hyperparameter Search Log - 2025-05-24 10:35:28
+Base Config for non-searched params: 6block
+Fixed Overrides (excluding searched params):
+  epochs: 150
+  theta: 100
+  use_ssl_augmentations: False
+  use_cifar10_norm: False
+  num_images: 3
+  test_subset: 200
+  peak_lr_weights: 0.001
+  hidden_lr_inference: 0.095
+  reconstruction_every_n_epochs: 75
+  validation_every_n_epochs: 75
+  use_inference_lr_scaling: True
+  use_lr_schedule_w: True
+  use_lr_schedule_h: True
+  weight_decay: 0.0002
+  mlp_ratio: 4.0
+  patch_size: 4
+  use_noise: True
+  update_weights_every_inference_step: False
+  use_early_stopping: True
+  early_stopping_patience: 7
+  early_stopping_min_delta: 0.0001
+  early_stopping_metric: train_mse
+  save_model_train_mse_threshold: 0.007
+  model_saving_metric: train_mse
+  use_vode_grad_norm: False
+  use_adamw_for_hidden_optimizer: False
+  corrupt_ratio: 0.25
+  use_lower_half_mask: False
+  inference_clamp_alpha: 1.0
+  save_reconstruction_images: True
+  save_reconstruction_video: True
+  video_fps: 5
+  reinitialize_model_for_each_epoch: False
+  use_status_init_in_training: False
+  use_status_init_in_unmasking: False
+  lr_schedule_min_lr_factor: 0.5
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Run | NB | BS   | HS   | NH | VodeLN | LR Hid    | Scale   | Inf Steps | Warmup | Hid Mom | H Clip | W Clip | Seed | Best Val MSE   | Run Best Train MSE | Final Train MSE | Status   | W&B Run Name                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+1   | 1  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 80   | 0.00046783     | 0.00041771         | 0.00043586      |          | nb1_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd80
+2   | 2  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 80   | 0.00239872     | 0.00233172         | 0.00257297      |          | nb2_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd80
+3   | 3  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 80   | 0.00302097     | 0.00284898         | 0.00350551      |          | nb3_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd80
+5   | 5  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 80   | 0.00525289     | 0.00643997         | 0.01280893      |          | nb5_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd80
+4   | 4  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 80   | Failed or Invalid | 0.00800053         | 0.00841786      | (ValFail) | nb4_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd80
+6   | 6  | 200  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 80   | Failed or Invalid | 0.01278122         | 0.02221716      | (ValFail) | nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd80
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Best Params: num_blocks=1, batch_size=200, hidden_size=64, num_heads=1, use_vode_state_layernorm=OFF, peak_lr_hidden=9.500e-02, inference_lr_scale_base=1.25, inference_steps=20, warmup_steps=0, hidden_momentum=0.40, h_grad_clip_norm=2000.0, w_grad_clip_norm=500.0, seed=80
+Achieved Overall Best Validation MSE: 0.000468
+Run Best Train MSE of Best Val Run: 0.00041771019459702075
+Final Train MSE of Best Val Run: 0.00043585815001279116
+ (lr_weights=1.000e-03 fixed)

--- a/results/hyperparam_search_results/hyperparam_search_results_6block_20250524_120919.txt
+++ b/results/hyperparam_search_results/hyperparam_search_results_6block_20250524_120919.txt
@@ -1,0 +1,49 @@
+Hyperparameter Search Log - 2025-05-24 12:09:19
+Base Config for non-searched params: 6block
+Fixed Overrides (excluding searched params):
+  epochs: 75
+  theta: 10000
+  use_ssl_augmentations: True
+  use_cifar10_norm: True
+  num_images: 3
+  test_subset: 500
+  peak_lr_weights: 0.001
+  hidden_lr_inference: 0.095
+  reconstruction_every_n_epochs: 75
+  validation_every_n_epochs: 75
+  use_inference_lr_scaling: True
+  use_lr_schedule_w: True
+  use_lr_schedule_h: True
+  weight_decay: 0.0002
+  mlp_ratio: 4.0
+  patch_size: 4
+  use_noise: True
+  update_weights_every_inference_step: False
+  use_early_stopping: True
+  early_stopping_patience: 20
+  early_stopping_min_delta: 0.0001
+  early_stopping_metric: train_mse
+  save_model_train_mse_threshold: 0.007
+  model_saving_metric: train_mse
+  use_vode_grad_norm: False
+  use_adamw_for_hidden_optimizer: False
+  corrupt_ratio: 0.25
+  use_lower_half_mask: False
+  inference_clamp_alpha: 1.0
+  save_reconstruction_images: True
+  save_reconstruction_video: True
+  video_fps: 5
+  reinitialize_model_for_each_epoch: False
+  use_status_init_in_training: False
+  use_status_init_in_unmasking: False
+  lr_schedule_min_lr_factor: 0.5
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Run | NB | BS   | HS   | NH | VodeLN | LR Hid    | Scale   | Inf Steps | Warmup | Hid Mom | H Clip | W Clip | Seed | Best Val MSE   | Run Best Train MSE | Final Train MSE | Status   | W&B Run Name                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+1   | 1  | 500  | 64   | 1  | OFF    | 9.500e-02 | 1.25    | 20        | 0      | 0.40    | 2000.0 | 500.0  | 80   | 0.00358999     | 0.00351370         | 0.00459483      | (Done)   | nb1_bs500_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd80
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Best Params: num_blocks=1, batch_size=500, hidden_size=64, num_heads=1, use_vode_state_layernorm=OFF, peak_lr_hidden=9.500e-02, inference_lr_scale_base=1.25, inference_steps=20, warmup_steps=0, hidden_momentum=0.40, h_grad_clip_norm=2000.0, w_grad_clip_norm=500.0, seed=80
+Achieved Overall Best Validation MSE: 0.003590
+Run Best Train MSE of Best Val Run: 0.003513696603477001
+Final Train MSE of Best Val Run: 0.0045948331244289875
+ (lr_weights=1.000e-03 fixed)

--- a/results/linear_probe_results/linear_probe_sweep_0block_20250523_172504.txt
+++ b/results/linear_probe_results/linear_probe_sweep_0block_20250523_172504.txt
@@ -1,0 +1,8 @@
+Linear Probe Sweep Results - Model: ../results/models/nb0_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd40_epoch10_trainmse0.000172_20250523_165959.npz, Config: 0block
+Probe LR: 0.001, Probe WD: 0.0001, Probe Epochs: 100
+Feature Extraction H LR: 0.095, Feature Extraction Steps: 20
+Global Average Pooling: True
+
+Vode Index/Combination | Test Accuracy | Num Features
+----------------------------------------------------
+0                        | 0.2692        | 48

--- a/results/linear_probe_results/linear_probe_sweep_1block_20250524_104552.txt
+++ b/results/linear_probe_results/linear_probe_sweep_1block_20250524_104552.txt
@@ -1,0 +1,8 @@
+Linear Probe Sweep Results - Model: ../results/models/nb1_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd80_epoch18_finalabstrainmse0.000436_20250524_100129.npz, Config: 1block
+Probe LR: 0.001, Probe WD: 0.0001, Probe Epochs: 100
+Feature Extraction H LR: 0.09351, Feature Extraction Steps: 20
+Global Average Pooling: True
+
+Vode Index/Combination | Test Accuracy | Num Features
+----------------------------------------------------
+0                        | 0.2418        | 48

--- a/results/linear_probe_results/linear_probe_sweep_1block_20250524_122213.txt
+++ b/results/linear_probe_results/linear_probe_sweep_1block_20250524_122213.txt
@@ -1,0 +1,8 @@
+Linear Probe Sweep Results - Model: ../results/models/nb1_bs500_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd80_epoch69_trainmse0.003560_20250524_120732.npz, Config: 1block
+Probe LR: 0.001, Probe WD: 0.0001, Probe Epochs: 100
+Feature Extraction H LR: 0.048514, Feature Extraction Steps: 20
+Global Average Pooling: True
+
+Vode Index/Combination | Test Accuracy | Num Features
+----------------------------------------------------
+0                        | 0.1781        | 48

--- a/results/linear_probe_results/linear_probe_sweep_1block_20250524_123207.txt
+++ b/results/linear_probe_results/linear_probe_sweep_1block_20250524_123207.txt
@@ -1,0 +1,8 @@
+Linear Probe Sweep Results - Model: ../results/models/nb1_bs500_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd80_epoch69_trainmse0.003560_20250524_120732.npz, Config: 1block
+Probe LR: 0.001, Probe WD: 0.0001, Probe Epochs: 100
+Feature Extraction H LR: 0.048514, Feature Extraction Steps: 20
+Global Average Pooling: True
+
+Vode Index/Combination | Test Accuracy | Num Features
+----------------------------------------------------
+0                        | 0.1717        | 48

--- a/results/linear_probe_results/linear_probe_sweep_1block_20250524_123742.txt
+++ b/results/linear_probe_results/linear_probe_sweep_1block_20250524_123742.txt
@@ -1,0 +1,8 @@
+Linear Probe Sweep Results - Model: ../results/models/nb1_bs500_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd80_epoch69_trainmse0.003560_20250524_120732.npz, Config: 1block
+Probe LR: 0.001, Probe WD: 0.0001, Probe Epochs: 100
+Feature Extraction H LR: 0.095, Feature Extraction Steps: 40
+Global Average Pooling: True
+
+Vode Index/Combination | Test Accuracy | Num Features
+----------------------------------------------------
+0                        | 0.1823        | 48

--- a/results/linear_probe_results/linear_probe_sweep_1block_20250524_124249.txt
+++ b/results/linear_probe_results/linear_probe_sweep_1block_20250524_124249.txt
@@ -1,0 +1,8 @@
+Linear Probe Sweep Results - Model: ../results/models/nb1_bs500_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd80_epoch69_trainmse0.003560_20250524_120732.npz, Config: 1block
+Probe LR: 0.001, Probe WD: 0.0001, Probe Epochs: 100
+Feature Extraction H LR: 0.095, Feature Extraction Steps: 20
+Global Average Pooling: True
+
+Vode Index/Combination | Test Accuracy | Num Features
+----------------------------------------------------
+0                        | 0.1840        | 48

--- a/results/linear_probe_results/linear_probe_sweep_2block_20250524_103755.txt
+++ b/results/linear_probe_results/linear_probe_sweep_2block_20250524_103755.txt
@@ -1,0 +1,8 @@
+Linear Probe Sweep Results - Model: ../results/models/nb2_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd80_epoch12_trainmse0.002394_20250524_100558.npz, Config: 2block
+Probe LR: 0.001, Probe WD: 0.0001, Probe Epochs: 100
+Feature Extraction H LR: 0.094372, Feature Extraction Steps: 20
+Global Average Pooling: True
+
+Vode Index/Combination | Test Accuracy | Num Features
+----------------------------------------------------
+0                        | 0.2081        | 48

--- a/results/linear_probe_results/linear_probe_sweep_6block_20250522_202756.txt
+++ b/results/linear_probe_results/linear_probe_sweep_6block_20250522_202756.txt
@@ -1,0 +1,15 @@
+Linear Probe Sweep Results - Model: ../results/models/model.npz, Config: 6block
+Probe LR: 0.001, Probe WD: 0.0001, Probe Epochs: 100
+Feature Extraction H LR: 0.055, Feature Extraction Steps: 40
+Global Average Pooling: True
+
+Vode Index | Test Accuracy
+--------------------------
+7          | 0.2092
+0          | 0.1774
+6          | 0.1721
+5          | 0.1277
+3          | 0.1258
+2          | 0.1002
+1          | 0.1000
+4          | 0.1000

--- a/results/linear_probe_results/linear_probe_sweep_6block_20250522_210012.txt
+++ b/results/linear_probe_results/linear_probe_sweep_6block_20250522_210012.txt
@@ -1,0 +1,8 @@
+Linear Probe Sweep Results - Model: ../results/models/model.npz, Config: 6block
+Probe LR: 0.001, Probe WD: 0.0001, Probe Epochs: 100
+Feature Extraction H LR: 0.055, Feature Extraction Steps: 100
+Global Average Pooling: True
+
+Vode Index | Test Accuracy
+--------------------------
+0          | 0.1664

--- a/results/linear_probe_results/linear_probe_sweep_6block_20250522_214158.txt
+++ b/results/linear_probe_results/linear_probe_sweep_6block_20250522_214158.txt
@@ -1,0 +1,8 @@
+Linear Probe Sweep Results - Model: ../results/models/model.npz, Config: 6block
+Probe LR: 0.001, Probe WD: 0.0001, Probe Epochs: 100
+Feature Extraction H LR: 0.095, Feature Extraction Steps: 20
+Global Average Pooling: True
+
+Vode Index/Combination | Test Accuracy | Num Features
+----------------------------------------------------
+_concat_0_1_2_3_4_5_6_7  | 0.2111        | 496

--- a/results/linear_probe_results/linear_probe_sweep_6block_20250522_233706.txt
+++ b/results/linear_probe_results/linear_probe_sweep_6block_20250522_233706.txt
@@ -1,0 +1,8 @@
+Linear Probe Sweep Results - Model: ../results/models/model.npz, Config: 6block
+Probe LR: 0.001, Probe WD: 0.0001, Probe Epochs: 100
+Feature Extraction H LR: 0.095, Feature Extraction Steps: 20
+Global Average Pooling: True
+
+Vode Index/Combination | Test Accuracy | Num Features
+----------------------------------------------------
+_concat_0_6_7            | 0.2256        | 176

--- a/results/linear_probe_results/linear_probe_sweep_6block_20250523_161638.txt
+++ b/results/linear_probe_results/linear_probe_sweep_6block_20250523_161638.txt
@@ -1,0 +1,8 @@
+Linear Probe Sweep Results - Model: ../results/models/nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd40_epoch51_trainmse0.007656_20250523_160048.npz, Config: 6block
+Probe LR: 0.001, Probe WD: 0.0001, Probe Epochs: 100
+Feature Extraction H LR: 0.095, Feature Extraction Steps: 20
+Global Average Pooling: True
+
+Vode Index/Combination | Test Accuracy | Num Features
+----------------------------------------------------
+0                        | 0.1616        | 48

--- a/results/linear_probe_results/linear_probe_sweep_6block_20250523_163419.txt
+++ b/results/linear_probe_results/linear_probe_sweep_6block_20250523_163419.txt
@@ -1,0 +1,8 @@
+Linear Probe Sweep Results - Model: ../results/models/nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd100_epoch40_valmse0.009117_20250523_142627.npz, Config: 6block
+Probe LR: 0.001, Probe WD: 0.0001, Probe Epochs: 100
+Feature Extraction H LR: 0.095, Feature Extraction Steps: 20
+Global Average Pooling: True
+
+Vode Index/Combination | Test Accuracy | Num Features
+----------------------------------------------------
+0                        | 0.1783        | 48

--- a/results/linear_probe_results/linear_probe_sweep_6block_20250523_205344.txt
+++ b/results/linear_probe_results/linear_probe_sweep_6block_20250523_205344.txt
@@ -1,0 +1,8 @@
+Linear Probe Sweep Results - Model: ../results/models/nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd80_epoch69_trainmse0.004531_20250523_173804.npz, Config: 6block
+Probe LR: 0.001, Probe WD: 0.0001, Probe Epochs: 100
+Feature Extraction H LR: 0.095, Feature Extraction Steps: 20
+Global Average Pooling: True
+
+Vode Index/Combination | Test Accuracy | Num Features
+----------------------------------------------------
+0                        | 0.1882        | 48

--- a/results/linear_probe_results/linear_probe_sweep_6block_20250523_225041.txt
+++ b/results/linear_probe_results/linear_probe_sweep_6block_20250523_225041.txt
@@ -1,0 +1,8 @@
+Linear Probe Sweep Results - Model: ../results/models/nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd80_epoch69_trainmse0.004531_20250523_173804.npz, Config: 6block
+Probe LR: 0.001, Probe WD: 0.0001, Probe Epochs: 100
+Feature Extraction H LR: 0.048514, Feature Extraction Steps: 20
+Global Average Pooling: True
+
+Vode Index/Combination | Test Accuracy | Num Features
+----------------------------------------------------
+_concat_0_6_7            | 0.2262        | 176

--- a/results/linear_probe_results/linear_probe_sweep_6block_20250524_212226.txt
+++ b/results/linear_probe_results/linear_probe_sweep_6block_20250524_212226.txt
@@ -1,0 +1,8 @@
+Linear Probe Sweep Results - Model: ../results/models/nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd80_epoch69_trainmse0.004531_20250523_173804.npz, Config: 6block
+Probe LR: 0.001, Probe WD: 0.0001, Probe Epochs: 100
+Feature Extraction H LR: 0.048514, Feature Extraction Steps: 20
+Global Average Pooling: True
+
+Vode Index/Combination | Test Accuracy | Num Features
+----------------------------------------------------
+_concat_0_1_2_3_4_5_6_7  | 0.2237        | 496

--- a/results/research_journal.md
+++ b/results/research_journal.md
@@ -472,8 +472,8 @@ Experiment:
       - Experiment with SSL + theta=10_000 + batch_size=500
         - epoch69_trainmse: 0.003560
         - nb1_bs500_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd80_epoch69_trainmse0.003560_20250524_120732.npz
-        - had to increase LR to starting 0.095 and steps to 40
-        - Vode 0 - Final Test Accuracy: 0.1823
+        - had to increase LR to starting 0.095
+        - Vode 0 - Final Test Accuracy: 0.1840
     - Block 2: 
       - epoch12_trainmse: 0.002394
       - Vode 0 - Final Test Accuracy: 0.2081

--- a/results/research_journal.md
+++ b/results/research_journal.md
@@ -286,6 +286,15 @@
   - Results:
     - I should have used more ES patience as I reduced validation from 10 to 5 epochs. With block 6 especially it lead to premature ES, but other blocks could have benefitted as well for more patience.
     - All settings reached below 0.008 MSE, so using the same settings seems fine
+
+- Experiment:
+  - Try best settings for 10 different seeds to check stability
+  - Run: [https://wandb.ai/neural-machines/pc-arch-search-recursing-meitner?nw=nwusergradientracer](https://wandb.ai/neural-machines/pc-arch-search-recursing-meitner?nw=nwusergradientracer)
+  - Results:
+    - hyperparam_search_results/hyperparam_search_results_6block_20250522_035339.txt
+    - All nicely converged
+    - Best val MSE 0.0042
+
 - Experiment: 
   - Trying to run best settings for different batch sizes to stabilise training, as well as trying layernorm for vode states
   - `batch_size = [200, 500, 1000]`
@@ -301,6 +310,7 @@
    - I have stopped the training early with the batch size 200 experiments finished as I did not see benefit of using layernorm.
   - Interpretation and next steps:
     - Just run the experiment on looking at the effect of modifying batch sizes
+
 - Experiment: 
   - Trying to run best settings for different batch sizes to stabilise training.
   - `batch_size = [200, 500, 1000]`
@@ -315,6 +325,7 @@
   - Results:
    - Batch size 200 is much better than the other setings.
    - more importantly there is no visible difference in training stability - still oscillating with higher batch size
+
 - Experiment: 
   - Just out of curiosity testing how robust are the hyperparams when we increase network size, adding more hidden_size and num_heads
   - `hidden_size_candidates = [64, 128, 256]`

--- a/results/research_journal.md
+++ b/results/research_journal.md
@@ -339,3 +339,186 @@
     - Let's stop now and do the linear probing tests
 
 
+I have a potential contamination, because during eval the latents have the info from the eval set. although they are likely overwritten in the following 50,000 * 20 steps, we shall make sure this is not a serious issue. Now running exp, where we only eval when we reach below 0.008 and we do reconstruction and model saving as well. 
+  - model saving is now implemented and can do it based on val threshold. first test if we meaningfully achieve low val mse or if it was all contaminated in prior runs.
+  - Ok it seems, that there was contamination, because the val scores are now higher, and the reconstructions are less accurate. But it still reconstructs the large scale image which is good.
+  - Now one question is whether I need actually the SGD momentum from train to effectively eval and reconstruct. Let's try that. Because in the latest run I used the new setup wherbeby I use completely separate optimisers for eval and recon, not the one from train.
+  - Great, actually there is no issue if we use the same optim_h as for train we get the same low 0.004 MSE for val without contamination - so SGD momentum is carried over I guess? Or maybe it was just bad luck in the initial test?
+
+
+
+
+- Experiment: 
+  - shuffling 
+  - theta 10000 
+  - image augmentations from vision_transformer script
+  - 500 epochs, decayed to 0.1
+  - 3 seeds
+  - Run: [https://wandb.ai/neural-machines/pc-arch-search-hardcore-varahamihira?nw=nwusergradientracer](https://wandb.ai/neural-machines/pc-arch-search-hardcore-varahamihira?nw=nwusergradientracer)
+  - Results:
+    - only finished one of the seeds but it diverged
+
+- Experiment:
+  - now running with 75 epochs: 
+  - Run: [https://wandb.ai/neural-machines/pc-arch-search-eloquent-jang?nw=nwusergradientracer](https://wandb.ai/neural-machines/pc-arch-search-eloquent-jang?nw=nwusergradientracer)
+  - from 3 seeds one seed reached 0.006 with shuffling and augmentations, the others early stopped as modified criteria to train_mse with 10 patience
+  - ../results/hyperparam_search_results/hyperparam_search_results_6block_20250523_083624.txt
+
+- Experiment:
+  - further change in data augmentation - added cifar10 specific normalisation and simplified augmentations - have to test if converges:
+  - Run: [https://wandb.ai/neural-machines/pc-arch-search-friendly-lehmann](https://wandb.ai/neural-machines/pc-arch-search-friendly-lehmann)
+  - Results:
+    - all stopped, and did not reach much:
+    - Achieved Overall Best Validation MSE: 0.015082
+    - Run Best Train MSE of Best Val Run: 0.01942340098321438
+  - Interpretation and next steps: 
+    - it was still downward trend when looking running average. maybe it needs more time with augmentaions to converge
+
+- Experiment:
+  - running the same as above but with more patience for 10 seeds:
+  - Run: [https://wandb.ai/neural-machines/pc-arch-search-boring-turing](https://wandb.ai/neural-machines/pc-arch-search-boring-turing)
+  - Results:
+   - all but 1 diverged or got worse from about epoch 35
+   - best run 0.013 - none of them reached near 0.008
+   - ../results/hyperparam_search_results/hyperparam_search_results_6block_20250523_134529.txt
+  - Interpretation and next steps:
+    - let's backtrack for now and double down on getting best possible run to do linear probing on
+
+
+- Experiment:
+  - New run to produce model artifact with best settings
+  - `seed_candidates = [40, 50, 60, 70, 80, 90, 100]`
+  - Run: [https://wandb.ai/neural-machines/pc-arch-search-adoring-northcutt?nw=nwusergradientracer](https://wandb.ai/neural-machines/pc-arch-search-adoring-northcutt?nw=nwusergradientracer)
+  - Results:
+    - Best run: nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd80_epoch69_trainmse0.004531_20250523_173804.npz
+    - MSE: 0.004531
+  - Linear probing:
+    - Vode 0 - Final Test Accuracy: 0.1882
+
+- Experiment:
+  - New run with above settings but for 150 epochs and to 0 LR decay
+  - `seed_candidates = [80]`
+  - `epochs = 150`
+  - `lr_schedule_min_lr_factor = 0`
+  - Run: [https://wandb.ai/neural-machines/pc-arch-search-lucid-maxwell](https://wandb.ai/neural-machines/pc-arch-search-lucid-maxwell)
+  - Results:
+    - Early stopped as it got stagnating and oscillating wildly
+
+- Experiment:
+  - Repeat run with lower weight updates
+  - `peak_lr_weights: 0.0001`
+  - `seed_candidates = [80]`
+  - `epochs = 150`
+  - `lr_schedule_min_lr_factor = 0.5`
+  - Run: [https://wandb.ai/neural-machines/pc-arch-search-sweet-lamport](https://wandb.ai/neural-machines/pc-arch-search-sweet-lamport)
+  - Results:
+    - Run Best Train MSE of Best Val Run: 0.017332421615719795
+  - Interpretation and next steps:
+    - I have missed to study the effect of weight LR on stability. This run is very stable with 0.0001 weight LR, but does not reach optimal levels. Also, interesting loss curve, going back up for a while after an initial downward trend, but then keeps coming back down again. Let's first try to add augmentations, to see if it helps the curve be consistently downward. 
+
+- Experiment:
+  - Repeat run with augmentations and cifar scaling
+  - `use_ssl_augmentations: True`
+  - `use_cifar10_norm: True`
+  - `peak_lr_weights: 0.0001`
+  - `seed_candidates = [80]`
+  - `epochs = 150`
+  - `lr_schedule_min_lr_factor = 0.5`
+  - Run: [https://wandb.ai/neural-machines/pc-arch-search-inspiring-wescoff](https://wandb.ai/neural-machines/pc-arch-search-inspiring-wescoff)
+  - Results:
+    - Did not help with the loss shape initially dropping but coming back up a bit and then dropping again. 
+    - Loss comes down much slower than without augmentation, it is harder to fit. But that is expected.
+    - It starts oscillating around epoch 45, while mse is only 0.042-0.052
+  - Interpretation:
+    - Not sure why still oscillates after a while. 
+
+- Experiment:
+  - Repeat above but bump up learning rate for weights.
+  - `theta = 100`
+  - `peak_lr_weights: 0.0005`
+  - `use_ssl_augmentations: True`
+  - `use_cifar10_norm: True`
+  - `seed_candidates = [80]`
+  - `epochs = 150`
+  - `lr_schedule_min_lr_factor = 0.5`
+  - Run: [https://wandb.ai/neural-machines/pc-arch-search-angry-williams](https://wandb.ai/neural-machines/pc-arch-search-angry-williams)
+  - Results:
+    - Too much, oscillates again. Stopped, as it looked that bad.
+  - Interpretation:
+    - Oscillations clearly get tamed with lower regimes, when we bumped up again they creep back in. But even in the above smooth setting oscillations start to accur around epoch 45. 
+
+
+- Experiment:
+  - Revisiting iPC and resetting h each epoch
+  - `use_status_init_in_training: True`
+  - `use_status_init_in_unmasking: True`
+  - `update_weights_every_inference_step: True`
+  - `theta = 10_000`
+  - `peak_lr_weights: 0.0001`
+  - `use_ssl_augmentations: True`
+  - `use_cifar10_norm: True`
+  - `seed_candidates = [80]`
+  - `epochs = 150`
+  - `lr_schedule_min_lr_factor = 0.5`
+  - Run: [https://wandb.ai/neural-machines/pc-arch-search-busy-chatterjee?nw=nwusergradientracer](https://wandb.ai/neural-machines/pc-arch-search-busy-chatterjee?nw=nwusergradientracer)
+  - Results:
+    - All diverged and higher than 0.3
+  - Interpretation:
+    - stop this line of experiments for now - refocus effort on linear probing and what affects linear probing scores
+
+
+
+Experiment:
+  - Creating models for each block variation with standard settings
+  - Results: 
+    - Blocks 0:
+      - epoch10_trainmse: 0.000172
+      - Vode 0 - Final Test Accuracy: 0.2692
+    - Block 1: 
+      - epoch18_trainmse: 0.000436
+      - Vode 0 - Final Test Accuracy: 0.2418
+    - Block 2: 
+      - epoch12_trainmse: 0.002394
+      - Vode 0 - Final Test Accuracy: 0.2081
+    - Block 3:
+      - epoch19_trainmse: 0.002849
+      - Vode 0 - Final Test Accuracy: 0.1971
+
+
+
+- Try next: 
+  - Get back to block1 - and iterate quicly with linear probing as direct feedback on how data augmentation, and regularisation can improve representations; I could also experiment faster with more hidden dim and num heads
+  - Block6:
+    - oscillation reduction: lower learning rate from 0.0005 ro 0.0003
+    - maybe need to revisit iPC
+    - have to revisit latent resetting
+    - outsource hyperparam search to cursor - before that merge the liner probing script to main, and experiment on new branch
+
+Criticism:
+  - normal ViT with the same architecture as my 6 block 1 head, 64 dim model reaches 76% accuracy in 64 epochs
+  - I think this means it has the representational capacity for good features. Good enough for this classification.
+  - it uses BP and has non-linearity
+  - Can it be that even though it has this high accuracy the learned features are still better in the PC model? I cannot really show evidence to that.
+
+Ideas to test:
+ - experiment with regularisation, especially L1 and L2 on h
+ - add dropout
+ - lower weight updates to 0.0001
+ - experiment with muzero like regularisation as planned. start small. commit first initial probing results.
+
+Current state:
+  - even with the close to all time best final train mse 0.004531 the linear probing results are merely 0.18 for vode_0
+  - something might be off with the feature creation, what if we have some catastrophic collapse of the hidden states? when I set the actual LR that was used when the model was extracted, then the image generated gets very bad. the reference video is generated after the feature extraction, so that proces already messed with the latents significantly. So,  I mean, if we reset h during training, and if we did that here as well, that is the only way we can ensure this does not happen. but I have not experimented with that setup for a long time. but, that setup could also ensure perhaps that we get better higher latents? it might force the network, to always try to find good representations from scratch, and not just rely on the weights. 
+
+
+Commands:
+ python linear_probe.py --config_name 6block --feature_layer_vode_indices "0,6,7" --concatenate_features True --probe_inference_steps 20 --probe_h_lr 0.048514  --model_path ../results/models/nb6_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e75_sd80_epoch69_trainmse0.004531_20250523_173804.npz
+
+Block 1:
+ python linear_probe.py --config_name 1block --feature_layer_vode_indices "0" --concatenate_features True --probe_inference_steps 20 --probe_h_lr 0.09351  --model_path ../results/models/nb1_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd80_epoch18_finalabstrainmse0.000436_20250524_100129.npz
+
+Block 2:
+ python linear_probe.py --config_name 2block --feature_layer_vode_indices "0" --concatenate_features True --probe_inference_steps 20 --probe_h_lr 0.094372 --model_path ../results/models/nb2_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd80_epoch12_trainmse0.002394_20250524_100558.npz
+
+Block 3:
+ python linear_probe.py --config_name 3block --feature_layer_vode_indices "0" --concatenate_features True --probe_inference_steps 20 --probe_h_lr 0.09333 --model_path ../results/models/nb3_bs200_hs64_nh1_lrh0p095_sb1p25_is20_ws0_hm0p40_hclip2000_wclip500_vlnOFF_e150_sd80_epoch19_trainmse0.002849_20250524_101515.npz


### PR DESCRIPTION
This pull request builds upon the successful scaling of the PC-ViT (v0.4.0) by introducing **linear probing capabilities (v0.5.0)** to evaluate the quality of learned representations. This marks a crucial step towards understanding the features learned during self-supervised pretraining.

Key Achievements & Additions:

*   **Linear Probing Framework**: Implemented `examples/linear_probe.py`, a script to perform linear probing on the CIFAR-10 dataset using features extracted from various layers (Vodes) of the pretrained PC-ViT models. This allows for quantitative assessment of feature quality by training a linear classifier on top of the frozen SSL-learned features.
*   **Initial Linear Probing Results**: Conducted initial linear probing experiments using the best performing 6-block model configuration (MSE ~0.0045).
    *   For the 6-block model (best train MSE 0.004531), linear probing from Vode 0 (top-most latent) achieved a test accuracy of approximately **0.1882**. Concatenating Vode 0, 6 and 7 yielded **0.2262**. Concatenating all vodes yielded **0.2237**
    *   Additional probing results for various block configurations (0, 1, 2, 3 blocks) using the same "best" hyperparameter set (adapted from 6-block success) are documented:
        *   **0-Block Model**:
            *   Pretext Train MSE: ~0.00017
            *   Vode 0 Linear Probe Test Accuracy: **~0.2692**
        *   **1-Block Model**:
            *   Pretext Train MSE: ~0.00043
            *   Vode 0 Linear Probe Test Accuracy: **~0.2418**
            *   A separate 1-block experiment with SSL augmentations, `theta=10000`, `batch_size=500`, and adjusted LR (pretext train MSE ~0.00356) yielded a Vode 0 linear probe accuracy of **~0.1840**.
        *   **2-Block Model**:
            *   Pretext Train MSE: ~0.00239
            *   Vode 0 Linear Probe Test Accuracy: **~0.2081**
        *   **3-Block Model**:
            *   Pretext Train MSE: ~0.00285
            *   Vode 0 Linear Probe Test Accuracy: **~0.1971**
*   **Reconstruction Visualization in Probing Script**: The `linear_probe.py` script now includes functionality to generate and save reconstruction videos, aiding in visual assessment during the feature extraction phase.
*   **Code Refinements**: The `debug_transformer_wandb.py` script has been updated with various configurations for different block numbers (`0block`, `1block`, `2block`, `5block`, `6block`) incorporating the best-found hyperparameters for SSL pretraining.

Experiments & Findings (Highlights from Research Journal & Probing):

*   **Representational Quality vs. Depth**: Initial linear probing results suggest that shallower models (0-1 blocks) can yield better linear separability on CIFAR-10 classification (e.g., 0-block at ~27% accuracy vs. 6-block at ~19% on Vode 0). This is an important finding and suggests that minimizing reconstruction MSE alone, especially with deeper architectures, might not directly correlate with optimal downstream task performance without further tuning or architectural considerations.
*   **Impact of SSL Settings on Probed Features**: The 1-block model trained with stronger SSL augmentations and a larger batch size showed a drop in linear probe accuracy (0.2418 -> 0.1840), even though its reconstruction MSE was still reasonable (0.00356). This highlights the sensitivity of learned representations to the specifics of the SSL pretraining setup and/or batch size used.
*   **Focus Shift**: The current results emphasize the need to use linear probing (and potentially other downstream tasks) as a more direct measure of representational quality, rather than solely relying on reconstruction MSE.
*   **Critique of Current Representations**: A standard Vision Transformer (ViT) with a similar architecture (i.e. depth, hidden size, heads) can achieve much higher classification accuracy (e.g., 76%), indicating significant room for improvement in the features learned by the current PC-ViT setup.
*   **Future Directions based on Probing**: The relatively low linear probing scores (compared to supervised baselines or other SSL methods) suggest several avenues for future work:
    *   Experimenting with regularization techniques (L1/L2 on `h`, dropout).
    *   Extended data augmentation and parameter tuning
    *   Further tuning of weight update learning rates.

How to Test:

1.  **Run Linear Probing**: Use the `examples/linear_probe.py` script to extract features and evaluate linear probe accuracy.
    *   Example command for a 6-block model:
        ```bash
        python examples/linear_probe.py --config_name 6block --feature_layer_vode_indices "0" --model_path ../results/models/model_to_test.npz --probe_h_lr 0.095 --probe_inference_steps 20
        ```
2.  **Reproduce SSL Pretraining (Optional)**: Use `examples/hyperparam_search.py` with configurations like `0block`, `1block`, etc., to pretrain models if needed.

Related Issues/Roadmap:

*   Advances roadmap item: "Implement and evaluate linear probing for CIFAR-10."
*   Provides foundational tools and initial benchmarks for "Tune SSL pretraining for better downstream task performance."